### PR TITLE
refactor: remove dead config fields and simplify workflow

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,9 +22,6 @@ func main() {
 
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
-		case "install":
-			runInstall()
-			return
 		case "setup":
 			runSetup()
 			return
@@ -45,14 +42,14 @@ func main() {
 			}
 			return
 		case "--version", "-v":
-			fmt.Printf("git-courer v%s\n", config.Default().MCP.Version)
+			fmt.Printf("git-courer v%s\n", config.ServerVersion)
 			return
 		case "version":
 			if len(os.Args) > 2 && os.Args[2] == "--predict" {
 				runVersionPredict()
 				return
 			}
-			fmt.Printf("git-courer v%s\n", config.Default().MCP.Version)
+			fmt.Printf("git-courer v%s\n", config.ServerVersion)
 			return
 		}
 	}
@@ -106,13 +103,6 @@ func runSetup() {
 	}
 }
 
-func runInstall() {
-	if err := installer.RunInstall(); err != nil {
-		fmt.Fprintf(os.Stderr, "Install failed: %v\n", err)
-		os.Exit(1)
-	}
-}
-
 func runRemove() {
 	projectDir := "."
 	if len(os.Args) > 2 {
@@ -154,7 +144,7 @@ func runMCPServer() {
 
 	srv := mcpserver.ServeWithAdapter(cfg, gitAdapter, ollamaAdapter, ollamaAdapter)
 
-	log.Printf("Starting git-courer v%s", cfg.MCP.Version)
+	log.Printf("Starting git-courer v%s", config.ServerVersion)
 	log.Printf("Working directory: %s", cfg.Git.WorkDir)
 	log.Printf("Ollama host: %s", cfg.Ollama.Host)
 	log.Printf("Ollama model: %s", cfg.Ollama.Model)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,6 @@
 ollama:
   host: http://localhost:11434
-  model: qwen3.5
+  model: gemma4:26b
   context_window: 0
   auto_start: false
   models_dir: ""
@@ -10,22 +10,16 @@ git:
   auto_add_secrets: true
   require_clean_repo: false
 
-validation:
-  require_confirmation: true
-  confirmation_method: elicitation  # elicitation | auto
-  max_commit_length: 72
-
 secrets:
   detection_mode: regex+ai
-  patterns: []
-
-ui:
-  theme: dark
-  show_icons: true
-
-mcp:
-  name: git-courer
-  version: ""
+  patterns:
+    - "*.key"
+    - "*.pem"
+    - ".env*"
+    - "credentials.json"
+    - "secrets.yaml"
+    - "*.password"
+    - "*.token"
 
 preview:
   enabled: true
@@ -36,6 +30,18 @@ preview:
     release: true
     tag_create: false
     tag_delete: false
+    tag_push: false
+    tag_delete_remote: false
+
+commit:
+  ttl: 10m
+  log_path: .gcourer/task.log
+  max_log_lines: 500
+
+release:
+  log_path: .gcourer/release.log
+  max_log_lines: 500
+  max_commits_per_chunk: 20
 
 commands:
   enabled_operations:
@@ -46,8 +52,10 @@ commands:
     - branch_create
     - branch_delete
     - merge
-    # - tag_create   # uncomment to enable
-    # - tag_delete  # uncomment to enable
+    - tag_create        # uncomment to enable
+    - tag_delete        # uncomment to enable
+    - tag_push          # uncomment to enable
+    - tag_delete_remote # uncomment to enable
 
 backup:
   enabled: true

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,7 +6,7 @@
 
 Edit one of:
 - `~/.config/git-courer/config.yaml` (global)
-- `.gcourer/config.yaml` (project)
+- `.gcourer/config.yaml` (project — overrides global)
 
 ```yaml
 ollama:
@@ -18,9 +18,6 @@ git:
 
 secrets:
   detection_mode: regex+ai
-
-validation:
-  require_confirmation: true
 
 preview:
   enabled: true
@@ -40,8 +37,8 @@ backup:
 |-------|------|---------|-------------|
 | host | string | http://localhost:11434 | Ollama server URL |
 | model | string | gemma4:26b | Model to use |
-| context_window | int | 0 | Context size (0=default) |
-| auto_start | bool | false | Auto-start Ollama |
+| context_window | int | 0 | Context window size (0 = model default) |
+| auto_start | bool | false | Auto-start Ollama if not running |
 | models_dir | string | "" | Custom models directory |
 
 ### git
@@ -54,40 +51,54 @@ backup:
 ### secrets
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| detection_mode | string | regex+ai | Detection mode: regex, ai, regex+ai |
+| detection_mode | string | regex+ai | Detection mode: `regex`, `ai`, `regex+ai` |
 | patterns | []string | *.key, *.pem, .env*, credentials.json, secrets.yaml, *.password, *.token | File patterns to check |
-| use_llm_security_scan | string | auto | Use LLM for scan: auto, true, false |
-
-### validation
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| require_confirmation | bool | true | Ask before executing destructive operations |
-| max_commit_length | int | 72 | Maximum commit message length |
+| use_llm_security_scan | string | auto | Use LLM for scan: `auto`, `true`, `false` |
 
 ### preview
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | enabled | bool | true | Enable preview dialogs |
+| operations | map[string]bool | see below | Per-operation preview flag |
 
-Operations that can require preview (map[string]bool):
-- commit
-- branch_create
-- branch_delete
-- release
-- tag_create
-- tag_delete
-- tag_push
-- tag_delete_remote
+Default per-operation values:
+
+| Operation | Preview required |
+|-----------|-----------------|
+| commit | true |
+| branch_create | true |
+| branch_delete | true |
+| release | true |
+| tag_create | false |
+| tag_delete | false |
+| tag_push | false |
+| tag_delete_remote | false |
+
+### commit
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| ttl | duration | 10m | How long a pending commit plan is valid |
+| log_path | string | .gcourer/task.log | Path to commit log file |
+| max_log_lines | int | 500 | Max log lines to feed the LLM |
+
+### release
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| log_path | string | .gcourer/release.log | Path to release log file |
+| max_log_lines | int | 500 | Max log lines to feed the LLM |
+| max_commits_per_chunk | int | 20 | Max commits per changelog chunk |
 
 ### commands
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| enabled_operations | []string | commit, release, push, pull, branch_create, branch_delete, merge, tag_create, tag_delete, tag_push, tag_delete_remote | Allowed commands |
+| enabled_operations | []string | commit, release, push, pull, branch_create, branch_delete, merge | Allowed operations |
+
+Available operation keys: `commit`, `release`, `push`, `pull`, `branch_create`, `branch_delete`, `merge`, `tag_create`, `tag_delete`, `tag_push`, `tag_delete_remote`
 
 ### backup
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| enabled | bool | true | Enable automatic backup before destructive operations |
+| enabled | bool | true | Create a git ref backup before every destructive operation |
 
 ## Examples
 
@@ -100,8 +111,6 @@ commands:
 
 ### No confirmations
 ```yaml
-validation:
-  require_confirmation: false
 preview:
   enabled: false
 ```
@@ -121,4 +130,10 @@ secrets:
     - ".env*"
     - "credentials.json"
     - "*.secret"
+```
+
+### Longer plan TTL
+```yaml
+commit:
+  ttl: 30m
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,20 +12,23 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// ServerName is the MCP server identifier registered with AI clients.
+const ServerName = "git-courer"
+
+// ServerVersion is the current MCP server version.
+const ServerVersion = "1.3.1"
+
 // Config represents the git-courer configuration.
-// [USER] fields are editable by users via config files.
-// [INTERNAL] fields are managed by git-courer and should not be manually edited.
+// All fields are editable by users via config files.
 type Config struct {
-	Ollama     OllamaConfig     `yaml:"ollama"`     // [USER] Ollama AI settings
-	Git        GitConfig        `yaml:"git"`        // [USER] Git behavior settings
-	Secrets    SecretsConfig    `yaml:"secrets"`    // [USER] Secrets detection
-	Validation ValidationConfig `yaml:"validation"` // [USER] Validation behavior
-	MCP        MCPConfig        `yaml:"mcp"`        // [USER] MCP server config
-	Preview    PreviewConfig    `yaml:"preview"`    // [USER] Preview/confirmation settings
-	Commit     CommitConfig     `yaml:"commit"`     // [USER] Commit workflow settings
-	Release    ReleaseConfig    `yaml:"release"`    // [USER] Release workflow settings
-	Commands   CommandsConfig   `yaml:"commands"`   // [USER] Enabled operations
-	Backup     BackupConfig     `yaml:"backup"`     // [USER] Auto-backup settings
+	Ollama   OllamaConfig   `yaml:"ollama"`   // Ollama AI settings
+	Git      GitConfig      `yaml:"git"`      // Git behavior settings
+	Secrets  SecretsConfig  `yaml:"secrets"`  // Secrets detection
+	Preview  PreviewConfig  `yaml:"preview"`  // Preview/confirmation settings
+	Commit   CommitConfig   `yaml:"commit"`   // Commit workflow settings
+	Release  ReleaseConfig  `yaml:"release"`  // Release workflow settings
+	Commands CommandsConfig `yaml:"commands"` // Enabled operations
+	Backup   BackupConfig   `yaml:"backup"`   // Auto-backup settings
 }
 
 // BackupConfig holds settings for the automatic backup system.
@@ -64,7 +67,7 @@ type OllamaConfig struct {
 // GitConfig holds git-related settings.
 // [USER] Configure git behavior.
 type GitConfig struct {
-	WorkDir          string `yaml:"workdir"`           // [USER] Default working directory
+	WorkDir          string `yaml:"workdir"`            // [USER] Default working directory
 	AutoAddSecrets   bool   `yaml:"auto_add_secrets"`   // [USER] Auto-stage detected secrets
 	RequireCleanRepo bool   `yaml:"require_clean_repo"` // [USER] Require clean working tree
 }
@@ -72,22 +75,9 @@ type GitConfig struct {
 // SecretsConfig holds secrets detection settings.
 // [USER] Configure secrets detection.
 type SecretsConfig struct {
-	DetectionMode      string   `yaml:"detection_mode"`       // [USER] Detection mode: regex, ai, regex+ai
+	DetectionMode      string   `yaml:"detection_mode"`        // [USER] Detection mode: regex, ai, regex+ai
 	Patterns           []string `yaml:"patterns"`              // [USER] Regex patterns for secrets
 	UseLLMSecurityScan string   `yaml:"use_llm_security_scan"` // [USER] Use LLM for security scan
-}
-
-// ValidationConfig holds validation settings.
-type ValidationConfig struct {
-	RequireConfirmation bool `yaml:"require_confirmation"` // [USER] Ask before executing
-	MaxCommitLength     int  `yaml:"max_commit_length"`    // [USER] Max commit message length
-}
-
-// MCPConfig holds MCP server settings.
-// [INTERNAL] Managed by git-courer setup.
-type MCPConfig struct {
-	Name    string `yaml:"name"`    // [INTERNAL] MCP server name
-	Version string `yaml:"version"` // [INTERNAL] MCP server version
 }
 
 // PreviewConfig holds preview/confirmation settings.
@@ -108,21 +98,16 @@ func (p PreviewConfig) IsRequired(operationKey string) bool {
 // CommitConfig holds commit-related settings including plan TTL and file paths.
 // [USER] Configure commit workflow behavior.
 type CommitConfig struct {
-	TTL                 DurationConfig `yaml:"ttl"`                  // [USER] Plan TTL
-	MaxPlanRetries      int            `yaml:"max_plan_retries"`     // [USER] Max retries for plan
-	LockFile            string         `yaml:"lock_file"`             // [INTERNAL] Lock file path
-	PlanFile            string         `yaml:"plan_file"`             // [INTERNAL] Plan file path
-	BlockerFile         string         `yaml:"blocker_file"`         // [INTERNAL] Blocker file path
-	LogPath             string         `yaml:"log_path"`             // [USER] Log file path
-	MaxLogLines         int            `yaml:"max_log_lines"`        // [USER] Max log lines
-	BackgroundThreshold int            `yaml:"background_threshold"` // [USER] Background threshold
+	TTL         DurationConfig `yaml:"ttl"`           // Plan TTL
+	LogPath     string         `yaml:"log_path"`      // Log file path
+	MaxLogLines int            `yaml:"max_log_lines"` // Max log lines
 }
 
 // ReleaseConfig holds release-related settings.
 // [USER] Configure release workflow behavior.
 type ReleaseConfig struct {
-	LogPath            string `yaml:"log_path"`             // [USER] Log file path
-	MaxLogLines        int    `yaml:"max_log_lines"`     // [USER] Max log lines
+	LogPath            string `yaml:"log_path"`              // [USER] Log file path
+	MaxLogLines        int    `yaml:"max_log_lines"`         // [USER] Max log lines
 	MaxCommitsPerChunk int    `yaml:"max_commits_per_chunk"` // [USER] Max commits per chunk
 }
 
@@ -183,36 +168,23 @@ func Default() *Config {
 				"secrets.yaml", "*.password", "*.token",
 			},
 		},
-		Validation: ValidationConfig{
-			RequireConfirmation: true,
-			MaxCommitLength:     72,
-		},
-		MCP: MCPConfig{
-			Name:    "git-courer",
-			Version: "1.3.0",
-		},
 		Preview: PreviewConfig{
 			Enabled: true,
 			Operations: map[string]bool{
-				"commit":         true,
-				"branch_create": true,
-				"branch_delete":  true,
-				"release":        true,
-				"tag_create":    false,
-				"tag_delete":    false,
-				"tag_push":       false,
+				"commit":            true,
+				"branch_create":     true,
+				"branch_delete":     true,
+				"release":           true,
+				"tag_create":        false,
+				"tag_delete":        false,
+				"tag_push":          false,
 				"tag_delete_remote": false,
 			},
 		},
 		Commit: CommitConfig{
-			TTL:                 NewDurationConfig(10 * time.Minute),
-			MaxPlanRetries:      3,
-			LockFile:            ".gcourer/git-courer.lock",
-			PlanFile:            ".gcourer/git-courer_plan.json",
-			BlockerFile:         ".gcourer/git-courer_commit.lock",
-			LogPath:             ".gcourer/task.log",
-			MaxLogLines:         500,
-			BackgroundThreshold: 10000,
+			TTL:         NewDurationConfig(10 * time.Minute),
+			LogPath:     ".gcourer/task.log",
+			MaxLogLines: 500,
 		},
 		Release: ReleaseConfig{
 			LogPath:            ".gcourer/release.log",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,12 +30,6 @@ func TestDefault_CommitPaths(t *testing.T) {
 	if cfg.Commit.LogPath == "" {
 		t.Error("Commit.LogPath should not be empty")
 	}
-	if cfg.Commit.PlanFile == "" {
-		t.Error("Commit.PlanFile should not be empty")
-	}
-	if cfg.Commit.BlockerFile == "" {
-		t.Error("Commit.BlockerFile should not be empty")
-	}
 	if cfg.Commit.MaxLogLines <= 0 {
 		t.Error("Commit.MaxLogLines should be positive")
 	}
@@ -58,13 +52,12 @@ func TestDefault_BackupEnabled(t *testing.T) {
 	}
 }
 
-func TestDefault_MCPVersion(t *testing.T) {
-	cfg := Default()
-	if cfg.MCP.Version == "" {
-		t.Error("MCP.Version should not be empty")
+func TestServerConstants(t *testing.T) {
+	if ServerName == "" {
+		t.Error("ServerName should not be empty")
 	}
-	if cfg.MCP.Name == "" {
-		t.Error("MCP.Name should not be empty")
+	if ServerVersion == "" {
+		t.Error("ServerVersion should not be empty")
 	}
 }
 
@@ -185,9 +178,8 @@ func TestLoadFromDir_UsesDefaults_WhenNoFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadFromDir() error: %v", err)
 	}
-	def := Default()
-	if cfg.MCP.Version != def.MCP.Version {
-		t.Errorf("MCP.Version = %q, want %q", cfg.MCP.Version, def.MCP.Version)
+	if cfg == nil {
+		t.Fatal("LoadFromDir() returned nil config")
 	}
 }
 
@@ -286,18 +278,16 @@ func TestLoadFromDir_GlobalConfigOverride(t *testing.T) {
 	cfgFile := filepath.Join(dir, ".gcourer", "config.yaml")
 	os.MkdirAll(filepath.Dir(cfgFile), 0755)
 
-	// Write config to project file
-	os.WriteFile(cfgFile, []byte(`validation:
-  require_confirmation: false
+	os.WriteFile(cfgFile, []byte(`ollama:
+  model: override-model
 `), 0644)
 
 	cfg, err := LoadFromDir(dir)
 	if err != nil {
 		t.Fatalf("LoadFromDir() error: %v", err)
 	}
-	// Project config should override defaults
-	if cfg.Validation.RequireConfirmation != false {
-		t.Errorf("RequireConfirmation = %v, want false", cfg.Validation.RequireConfirmation)
+	if cfg.Ollama.Model != "override-model" {
+		t.Errorf("Ollama.Model = %q, want override-model", cfg.Ollama.Model)
 	}
 }
 
@@ -397,26 +387,10 @@ func TestDefault_SecretsConfig(t *testing.T) {
 	}
 }
 
-func TestDefault_ValidationConfig(t *testing.T) {
-	cfg := Default()
-	if !cfg.Validation.RequireConfirmation {
-		t.Error("Validation.RequireConfirmation should be true by default")
-	}
-	if cfg.Validation.MaxCommitLength <= 0 {
-		t.Error("Validation.MaxCommitLength should be positive")
-	}
-}
-
 func TestDefault_CommitConfig(t *testing.T) {
 	cfg := Default()
-	if cfg.Commit.MaxPlanRetries <= 0 {
-		t.Error("Commit.MaxPlanRetries should be positive")
-	}
-	if cfg.Commit.LockFile == "" {
-		t.Error("Commit.LockFile should not be empty")
-	}
-	if cfg.Commit.BackgroundThreshold <= 0 {
-		t.Error("Commit.BackgroundThreshold should be positive")
+	if cfg.Commit.MaxLogLines <= 0 {
+		t.Error("Commit.MaxLogLines should be positive")
 	}
 }
 

--- a/internal/delivery/mcp/handlers.go
+++ b/internal/delivery/mcp/handlers.go
@@ -115,7 +115,7 @@ func registerTools(s *server.MCPServer, srv *Server) {
 			mcpgo.WithString("command", mcpgo.Description("e.g. COMMIT_START | COMMIT_APPLY | BRANCH_CREATE_START | BRANCH_CREATE_APPLY | BRANCH_DELETE_START | MERGE_START"), mcpgo.Required()),
 			mcpgo.WithString("instruction", mcpgo.Description("Natural language instruction for START phase")),
 			mcpgo.WithString("branch", mcpgo.Description("Branch name")),
-			mcpgo.WithBoolean("preview", mcpgo.Description(fmt.Sprintf("If true, show preview before executing (default: %v)", srv.cfg.Validation.RequireConfirmation))),
+			mcpgo.WithBoolean("preview", mcpgo.Description("If true, show preview before executing (default: depends on preview config)")),
 		),
 		srv.handleGitWriteReview,
 	)
@@ -367,8 +367,7 @@ func (s *Server) handleGitWriteReview(ctx context.Context, req mcpgo.CallToolReq
 
 // handleCommitOperation handles commit operations using CommitService.
 func (s *Server) handleCommitOperation(_ context.Context, req mcpgo.CallToolRequest, phase string) (*mcpgo.CallToolResult, error) {
-	requireConfirmation := s.cfg.Validation.RequireConfirmation
-	preview := req.GetBool("preview", requireConfirmation)
+	preview := req.GetBool("preview", s.cfg.Preview.IsRequired("commit"))
 
 	switch phase {
 	case "start":
@@ -546,6 +545,9 @@ func (s *Server) handleRelease(_ context.Context, req mcpgo.CallToolRequest, pha
 			instruction = "sacar versión"
 		}
 
+		requireConfirmation := s.cfg.Preview.IsRequired("release")
+		preview := req.GetBool("preview", requireConfirmation)
+
 		keepalive := s.startKeepalive("Preparing release", 30*time.Second)
 		s.releaseSvc.ClearPending()
 
@@ -568,7 +570,9 @@ func (s *Server) handleRelease(_ context.Context, req mcpgo.CallToolRequest, pha
 		s.releaseSvc.SaveChangelog(changelog)
 
 		allWarnings := append(warnings, warningsGen...)
-		s.releaseConfirm.CreateBlocker()
+		if preview {
+			s.releaseConfirm.CreateBlocker()
+		}
 
 		authenticated, _ := s.git.IsGHAuthenticated()
 		ghStatus := "authenticated"

--- a/internal/delivery/mcp/server.go
+++ b/internal/delivery/mcp/server.go
@@ -75,7 +75,6 @@ func New(cfg *config.Config, git ports.Git, llm ports.LLM, ollamaLifecycle Ollam
 	// Workflow engines.
 	commitCfg := workflow.DefaultCommitServiceConfig(
 		cfg.Ollama.ContextWindow,
-		cfg.Commit.BackgroundThreshold,
 		cfg.Commit.MaxLogLines,
 		cfg.Commit.LogPath,
 	)
@@ -118,8 +117,8 @@ func New(cfg *config.Config, git ports.Git, llm ports.LLM, ollamaLifecycle Ollam
 	})
 
 	s := server.NewMCPServer(
-		cfg.MCP.Name,
-		cfg.MCP.Version,
+		config.ServerName,
+		config.ServerVersion,
 		server.WithToolCapabilities(true),
 		server.WithRecovery(),
 		server.WithHooks(hooks),

--- a/internal/installer/hooks.go
+++ b/internal/installer/hooks.go
@@ -25,10 +25,6 @@ git:
   workdir: .
 secrets:
   detection_mode: regex+ai
-validation:
-  require_confirmation: true
-mcp:
-  name: git-courer
 preview:
   enabled: true
   operations:

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
-	"strings"
 )
 
 const (
@@ -17,91 +15,6 @@ const (
 	// Repo is the GitHub repository.
 	Repo = "git-courer"
 )
-
-// RunInstall performs the installation.
-func RunInstall() error {
-	fmt.Println("Installing git-courer...")
-
-	platform := Detect()
-	fmt.Printf("  Platform: %s\n", platform)
-
-	// Fetch latest release
-	release, err := FetchLatestRelease(Owner, Repo)
-	if err != nil {
-		return fmt.Errorf("failed to fetch release: %w", err)
-	}
-
-	asset := release.FindAsset(platform)
-	if asset == nil {
-		return fmt.Errorf("no binary for platform %s", platform)
-	}
-
-	// Download
-	fmt.Printf("  Downloading: %s\n", asset.Name)
-	tmpTar := "/tmp/" + platform.GitHubAsset() + ".tar.gz"
-
-	if err := asset.DownloadAsset(tmpTar); err != nil {
-		return fmt.Errorf("download failed: %w", err)
-	}
-
-	// Extract binary
-	binaryName := BinaryName
-	if platform.OS == "windows" {
-		binaryName += ".exe"
-	}
-
-	tmpBinary, err := extractBinaryFromTarGz(tmpTar, binaryName)
-	if err != nil {
-		os.Remove(tmpTar)
-		return fmt.Errorf("failed to extract: %w", err)
-	}
-
-	os.Remove(tmpTar)
-
-	// Install
-	installPath := GetInstallPath()
-	if err := os.MkdirAll(installPath, 0755); err != nil {
-		return fmt.Errorf("failed to create install dir: %w", err)
-	}
-
-	destPath := filepath.Join(installPath, BinaryName)
-	if platform.OS == "windows" {
-		destPath += ".exe"
-	}
-
-	// Remove existing binary first (force replace)
-	if err := os.Remove(destPath); err != nil && !os.IsNotExist(err) {
-		os.Remove(tmpBinary)
-		return fmt.Errorf("failed to remove old binary: %w", err)
-	}
-
-	// Copy instead of rename to avoid EXDEV
-	if err := copyFile(tmpBinary, destPath); err != nil {
-		os.Remove(tmpBinary)
-		return fmt.Errorf("failed to install: %w", err)
-	}
-
-	os.Remove(tmpBinary)
-	os.Chmod(destPath, 0755)
-
-	fmt.Printf("  Installed to: %s\n", destPath)
-
-	// Setup PATH
-	if err := setupPATH(installPath); err != nil {
-		fmt.Fprintf(os.Stderr, "  PATH setup: %v\n", err)
-	}
-
-	// Setup MCP
-	binPath, _ := FindBinaryPath()
-	if configured, err := ConfigureAllMCP(binPath); err != nil {
-		fmt.Fprintf(os.Stderr, "  MCP setup: %v\n", err)
-	} else if configured > 0 {
-		fmt.Printf("  %d MCP client(s) configured\n", configured)
-	}
-
-	fmt.Println("\n✓ git-courer installed successfully!")
-	return nil
-}
 
 // RunSetup runs project setup.
 func RunSetup(projectDir string) error {
@@ -202,64 +115,3 @@ func RunUpdate(force bool) error {
 	return nil
 }
 
-// setupPATH adds the install directory to PATH if needed.
-func setupPATH(installDir string) error {
-	// Check if already in PATH
-	currentPath := os.Getenv("PATH")
-	if strings.Contains(currentPath, installDir) {
-		return nil
-	}
-
-	// Detect shell
-	shell := os.Getenv("SHELL")
-	var rcFile string
-
-	switch {
-	case strings.Contains(shell, "bash"):
-		if home := os.Getenv("HOME"); home != "" {
-			rcFile = filepath.Join(home, ".bashrc")
-			if _, err := os.Stat(rcFile); err != nil {
-				rcFile = filepath.Join(home, ".bash_profile")
-			}
-		}
-	case strings.Contains(shell, "zsh"):
-		if home := os.Getenv("HOME"); home != "" {
-			rcFile = filepath.Join(home, ".zshrc")
-		}
-	case strings.Contains(shell, "fish"):
-		if home := os.Getenv("HOME"); home != "" {
-			rcFile = filepath.Join(home, ".config", "fish", "config.fish")
-		}
-	default:
-		// Try to detect
-		home := os.Getenv("HOME")
-		if home != "" {
-			if runtime.GOOS == "darwin" {
-				rcFile = filepath.Join(home, ".zshrc")
-			} else {
-				rcFile = filepath.Join(home, ".bashrc")
-			}
-		}
-	}
-
-	if rcFile == "" {
-		return nil
-	}
-
-	// Check if already configured
-	if data, err := os.ReadFile(rcFile); err == nil {
-		if strings.Contains(string(data), "git-courer") {
-			return nil
-		}
-	}
-
-	// Add PATH export
-	f, err := os.OpenFile(rcFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	_, err = f.WriteString(fmt.Sprintf("\n# git-courer\nexport PATH=\"$PATH:%s\"\n", installDir))
-	return err
-}

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -49,9 +49,9 @@ func TestPlatform_GitHubAsset(t *testing.T) {
 		platform *Platform
 		want     string
 	}{
-		{&Platform{OS: "linux", Arch: "amd64"}, "git-courer-linux-amd64"},
-		{&Platform{OS: "darwin", Arch: "arm64"}, "git-courer-darwin-arm64"},
-		{&Platform{OS: "windows", Arch: "amd64"}, "git-courer-windows-amd64"},
+		{&Platform{OS: "linux", Arch: "amd64"}, "git-courer_linux_amd64"},
+		{&Platform{OS: "darwin", Arch: "arm64"}, "git-courer_darwin_arm64"},
+		{&Platform{OS: "windows", Arch: "amd64"}, "git-courer_windows_amd64"},
 	}
 	for _, tc := range tests {
 		got := tc.platform.GitHubAsset()
@@ -445,6 +445,9 @@ func TestRemoveProject_CleansUp(t *testing.T) {
 }
 
 func TestSetupHooks_CreatesExecutableHook(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bit check not supported on Windows")
+	}
 	dir := t.TempDir()
 	os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0755)
 

--- a/internal/installer/mcp_config.go
+++ b/internal/installer/mcp_config.go
@@ -65,6 +65,7 @@ func MCPClients() []*MCPClient {
 			ConfigFn: func(binPath string) map[string]interface{} {
 				return map[string]interface{}{
 					"type":    "local",
+					"enabled": true,
 					"command": []string{binPath, "mcp"},
 				}
 			},

--- a/internal/installer/update.go
+++ b/internal/installer/update.go
@@ -63,13 +63,11 @@ func DownloadUpdate() error {
 	}
 
 	// Find current binary
-	currentPath, err := FindBinaryPath()
+	currentPath, err := os.Executable()
 	if err != nil {
-		// Try common paths
-		currentPath = "/usr/local/bin/git-courer"
-		if runtime.GOOS == "windows" {
-			currentPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "Programs", "git-courer", "git-courer.exe")
-		}
+		os.Remove(tmpBinary)
+		os.Remove(tmpTar)
+		return fmt.Errorf("failed to get current executable path: %w", err)
 	}
 
 	// Remove existing binary first (force replace)

--- a/internal/integration/ollama_flow_test.go
+++ b/internal/integration/ollama_flow_test.go
@@ -88,7 +88,6 @@ func TestCommitService_PrepareCommit_FullFlow(t *testing.T) {
 
 	commitCfg := workflow.DefaultCommitServiceConfig(
 		4096,
-		10000,
 		50,
 		filepath.Join(testWorkDir, "commit.log"),
 	)
@@ -167,7 +166,6 @@ func TestCommitService_Execute_DryRun(t *testing.T) {
 
 	commitCfg := workflow.DefaultCommitServiceConfig(
 		4096,
-		10000,
 		50,
 		filepath.Join(testWorkDir, "commit-dryrun.log"),
 	)

--- a/internal/integration/workflow_matrix_test.go
+++ b/internal/integration/workflow_matrix_test.go
@@ -141,7 +141,6 @@ func makeCommitSvc(t *testing.T, gitA ports.Git, llmA ports.LLM, sec ports.Secur
 	t.Helper()
 	cfg := workflow.DefaultCommitServiceConfig(
 		4096,
-		100_000,
 		50,
 		filepath.Join(dir, ".gcourer", "commit.log"),
 	)

--- a/internal/workflow/commit.go
+++ b/internal/workflow/commit.go
@@ -19,23 +19,21 @@ import (
 
 // CommitServiceConfig holds tuneable values for the commit service.
 type CommitServiceConfig struct {
-	BackgroundThreshold int    // diff size (chars) above which we run async
-	ChunkSize           int    // max chars per diff chunk sent to LLM
-	MaxLogLines         int    // circular buffer size for task.log
-	LogPath             string // path to task log file
+	ChunkSize   int    // max chars per diff chunk sent to LLM
+	MaxLogLines int    // circular buffer size for task.log
+	LogPath     string // path to task log file
 }
 
 // DefaultCommitServiceConfig returns sensible defaults derived from Ollama context window.
-func DefaultCommitServiceConfig(contextWindow, backgroundThreshold, maxLogLines int, logPath string) CommitServiceConfig {
+func DefaultCommitServiceConfig(contextWindow, maxLogLines int, logPath string) CommitServiceConfig {
 	cw := contextWindow
 	if cw == 0 {
 		cw = 4096
 	}
 	return CommitServiceConfig{
-		BackgroundThreshold: backgroundThreshold,
-		ChunkSize:           cw / 2,
-		MaxLogLines:         maxLogLines,
-		LogPath:             logPath,
+		ChunkSize:   cw / 2,
+		MaxLogLines: maxLogLines,
+		LogPath:     logPath,
 	}
 }
 
@@ -192,11 +190,6 @@ func (s *CommitService) Execute(instruction string, preview bool) (string, error
 	}
 
 	log.Printf("[DEBUG] Execute: prepared %d chunks, %d deleted files", len(state.chunks), len(state.deleted))
-	if len(state.chunks) > 3 || len(state.chunks)*s.cfg.ChunkSize > s.cfg.BackgroundThreshold {
-		log.Printf("[DEBUG] Execute: using background mode")
-		return s.executeBackground(instruction, state.chunks, state.deleted)
-	}
-	log.Printf("[DEBUG] Execute: using sync mode")
 	return s.executeSync(instruction, state.chunks, state.deleted)
 }
 
@@ -457,70 +450,6 @@ func (s *CommitService) executeSync(instruction string, chunks []domain.DiffChun
 
 	s.taskLog.logDone(len(committed))
 	resp, _ := json.Marshal(CommitResult{Operation: "commit", Commits: committed, Warnings: warnings, Type: "write"})
-	return string(resp), nil
-}
-
-func (s *CommitService) executeBackground(instruction string, chunks []domain.DiffChunk, deleted []string) (string, error) {
-	s.taskLog.logStart()
-	s.taskLog.logProgress(0, len(chunks))
-	shouldPush := strings.Contains(strings.ToLower(instruction), "push")
-
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-		defer cancel()
-
-		var committed []string
-		resultChan := make(chan chunkResult, len(chunks))
-		go func() {
-			for i, chunk := range chunks {
-				select {
-				case <-ctx.Done():
-					resultChan <- chunkResult{index: i, err: ctx.Err()}
-					continue
-				default:
-				}
-				msg, err := s.llm.GenerateChunkMessage(chunk)
-				resultChan <- chunkResult{chunk: chunk, message: msg, index: i, err: err}
-			}
-			close(resultChan)
-		}()
-
-		for r := range resultChan {
-			if r.err != nil {
-				s.taskLog.logError(fmt.Sprintf("Chunk %d failed: %v", r.index+1, r.err))
-				continue
-			}
-			if len(r.chunk.Files) == 0 {
-				continue
-			}
-			if err := s.git.Add(r.chunk.Files); err != nil {
-				s.taskLog.logError(fmt.Sprintf("failed to stage chunk %d: %v", r.index+1, err))
-				continue
-			}
-			if _, err := s.git.Commit(r.message); err != nil {
-				s.taskLog.logError(fmt.Sprintf("failed commit %d: %v", r.index+1, err))
-				continue
-			}
-			committed = append(committed, r.message)
-			s.taskLog.logCommit(r.message)
-			s.taskLog.logProgress(len(committed), len(chunks))
-		}
-
-		if len(committed) > 0 && shouldPush {
-			pushResult, err := s.git.Push()
-			if err != nil {
-				s.taskLog.logError(fmt.Sprintf("push failed: %v", err))
-			} else {
-				s.taskLog.logPush(pushResult)
-			}
-		}
-		s.taskLog.logDone(len(committed))
-	}()
-
-	resp, _ := json.Marshal(map[string]any{
-		"operation": "commit", "type": "write", "state": "running",
-		"message": fmt.Sprintf("Processing %d chunks in background. Check %q for progress.", len(chunks), s.cfg.LogPath),
-	})
 	return string(resp), nil
 }
 

--- a/internal/workflow/commit_execute_test.go
+++ b/internal/workflow/commit_execute_test.go
@@ -192,9 +192,8 @@ func TestCommitService_Rollback_OnCommitError(t *testing.T) {
 	}
 }
 
-// TestCommitService_Execute_Background runs the background path (>3 chunks).
-func TestCommitService_Execute_Background(t *testing.T) {
-	// Create 4 chunks to trigger the background path
+// TestCommitService_Execute_MultiChunk runs Execute with 4 chunks synchronously.
+func TestCommitService_Execute_MultiChunk(t *testing.T) {
 	git := &stubGit{
 		statusResult: domain.Status{
 			Files: []domain.FileStatus{
@@ -206,7 +205,6 @@ func TestCommitService_Execute_Background(t *testing.T) {
 	llm := &stubLLM{chunkMsg: "feat: chunk"}
 	security := &stubSecurity{}
 
-	// Use a small background threshold so 1 chunk triggers background
 	chunker := &stubDiffChunker{
 		chunks: []domain.DiffChunk{
 			{Files: []string{"a.go"}, Diff: "d1"},
@@ -215,18 +213,17 @@ func TestCommitService_Execute_Background(t *testing.T) {
 			{Files: []string{"d.go"}, Diff: "d4"},
 		},
 	}
-	cfg := DefaultCommitServiceConfig(4096, 0, 50, t.TempDir()+"/c.log") // threshold=0 → background for any size
+	cfg := DefaultCommitServiceConfig(4096, 50, t.TempDir()+"/c.log")
 	svc := NewCommitService(git, llm, chunker, security, cfg)
 
 	result, err := svc.Execute("commit all", false)
 	if err != nil {
-		t.Fatalf("Execute() background error: %v", err)
+		t.Fatalf("Execute() error: %v", err)
 	}
 	if result == "" {
-		t.Error("Execute() background returned empty result")
+		t.Error("Execute() returned empty result")
 	}
-	// Background mode returns JSON with "running" state
-	if !strings.Contains(result, "running") && len(git.commitCalls) == 0 {
-		t.Log("Background mode either returned 'running' or committed synchronously — both OK")
+	if len(git.commitCalls) == 0 {
+		t.Error("Execute() should have committed synchronously")
 	}
 }

--- a/internal/workflow/commit_service_test.go
+++ b/internal/workflow/commit_service_test.go
@@ -130,7 +130,7 @@ func (s *stubSecurity) ShouldUseLLMScan() bool { return false }
 
 func newCommitSvcWithPath(git *stubGit, llm *stubLLM, security *stubSecurity, logPath string) *CommitService {
 	chunker := &stubDiffChunker{}
-	cfg := DefaultCommitServiceConfig(4096, 100000, 50, logPath)
+	cfg := DefaultCommitServiceConfig(4096, 50, logPath)
 	return NewCommitService(git, llm, chunker, security, cfg)
 }
 
@@ -298,7 +298,7 @@ func TestCommitService_ExecuteFromPlan_NoCommitsGenerated(t *testing.T) {
 }
 
 func TestCommitService_DefaultConfig(t *testing.T) {
-	cfg := DefaultCommitServiceConfig(4096, 10000, 100, "/tmp/log")
+	cfg := DefaultCommitServiceConfig(4096, 100, "/tmp/log")
 	if cfg.ChunkSize <= 0 {
 		t.Error("ChunkSize should be positive")
 	}
@@ -311,7 +311,7 @@ func TestCommitService_DefaultConfig(t *testing.T) {
 }
 
 func TestCommitService_DefaultConfig_ZeroContextWindow(t *testing.T) {
-	cfg := DefaultCommitServiceConfig(0, 10000, 50, "/tmp/log")
+	cfg := DefaultCommitServiceConfig(0, 50, "/tmp/log")
 	// Should use default context window
 	if cfg.ChunkSize <= 0 {
 		t.Error("ChunkSize should be positive even with 0 context window input")

--- a/test/e2e/workflow_test.go
+++ b/test/e2e/workflow_test.go
@@ -135,7 +135,7 @@ func TestCommitPreviewDoesNotExecute(t *testing.T) {
 	chunker := &mockDiffChunker{}
 	security := &mockSecurity{}
 
-	cfg := workflow.DefaultCommitServiceConfig(4096, 100000, 50, tempLogPath(t))
+	cfg := workflow.DefaultCommitServiceConfig(4096, 50, tempLogPath(t))
 	svc := workflow.NewCommitService(git, llm, chunker, security, cfg)
 
 	// PrepareCommit should NOT call git.Commit — it only generates messages


### PR DESCRIPTION
- Remove ValidationConfig, MCPConfig, BackgroundThreshold, MaxPlanRetries, LockFile/PlanFile/BlockerFile from config
- Replace MCPConfig with package-level ServerName/ServerVersion constants
- Remove async background execution from CommitService (always sync)
- Remove git-courer install CLI command (curl install.sh is self-contained)
- Replace FindBinaryPath fallback in update.go with os.Executable()
- Make handleRelease respect Preview.IsRequired("release") like commit does
- Remove in-memory confirm file-path config fields (MCP notifications only)
- Update config.example.yaml to reflect actual user-editable options
- Rewrite docs/config.md with clean user-facing reference
- Fix pre-existing installer test failures (asset format, opencode enabled flag, Windows hook skip)