### PR TITLE
Fix/update install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ Releases combine two things: **Go calculates the version** from your commit type
 
 Run `git-courer setup` to configure all detected tools at once, or `git-courer mcp cursor` for a specific one.
 
+## Commands
+
+git-courer is not a CLI tool — it runs as an MCP server invoked automatically by your AI assistant. These are the management commands for installation and maintenance:
+
+| Command | Description |
+|---------|-------------|
+| `git-courer setup` | Set up git-courer in the current project |
+| `git-courer remove` | Remove git-courer from the current project |
+| `git-courer uninstall` | Uninstall the binary globally |
+| `git-courer update` | Update to the latest version |
+| `git-courer mcp setup` | Configure all detected AI tools |
+| `git-courer mcp setup <client>` | Configure a specific tool (e.g. `cursor`) |
+| `git-courer version` | Show current version |
+| `git-courer version --predict` | Predict next semver from commits since last tag |
+
 ## Configuration
 
 Run `git-courer setup` in your project — it creates `.gcourer/config.yaml` with sensible defaults.

--- a/internal/installer/hooks.go
+++ b/internal/installer/hooks.go
@@ -37,69 +37,15 @@ preview:
 		}
 	}
 
-	// Setup git hooks
-	if err := SetupHooks(projectDir); err != nil {
-		return fmt.Errorf("failed to setup hooks: %w", err)
-	}
-
-	return nil
-}
-
-// SetupHooks creates git hooks for the project.
-func SetupHooks(projectDir string) error {
-	hooksDir := filepath.Join(projectDir, ".git", "hooks")
-	if err := os.MkdirAll(hooksDir, 0755); err != nil {
-		return fmt.Errorf("failed to create hooks dir: %w", err)
-	}
-
-	preCommitPath := filepath.Join(hooksDir, "pre-commit")
-	gitCourerPath, err := FindBinaryPath()
-	if err != nil {
-		gitCourerPath = "git-courer"
-	}
-
-	hookContent := fmt.Sprintf(`#!/bin/sh
-# git-courer pre-commit hook
-# Run git-courer to check for secrets before commit
-command -v %s >/dev/null 2>&1 && %s check-secrets "$@"
-`, gitCourerPath, gitCourerPath)
-
-	if err := os.WriteFile(preCommitPath, []byte(hookContent), 0755); err != nil {
-		return fmt.Errorf("failed to write pre-commit hook: %w", err)
-	}
-
 	return nil
 }
 
 // RemoveProject removes git-courer from a project directory.
 func RemoveProject(projectDir string) error {
-	// Remove .gcourer directory
 	gcourerDir := filepath.Join(projectDir, ".gcourer")
 	if err := os.RemoveAll(gcourerDir); err != nil {
 		return fmt.Errorf("failed to remove .gcourer dir: %w", err)
 	}
-
-	// Remove git hooks
-	if err := RemoveHooks(projectDir); err != nil {
-		return fmt.Errorf("failed to remove hooks: %w", err)
-	}
-
-	return nil
-}
-
-// RemoveHooks removes git hooks created by git-courer.
-func RemoveHooks(projectDir string) error {
-	hooksDir := filepath.Join(projectDir, ".git", "hooks")
-	preCommitPath := filepath.Join(hooksDir, "pre-commit")
-
-	// Check if file contains git-courer reference
-	if data, err := os.ReadFile(preCommitPath); err == nil {
-		content := string(data)
-		if len(content) > 0 && len(content) > 30 && content[:30] == "#!/bin/sh\n# git-courer pre-commit" {
-			os.Remove(preCommitPath)
-		}
-	}
-
 	return nil
 }
 

--- a/internal/installer/update.go
+++ b/internal/installer/update.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/Alejandro-M-P/git-courer/internal/config"
 )
 
 // CheckForUpdates checks if a new version is available.
@@ -173,7 +175,7 @@ func copyFile(src, dst string) error {
 }
 
 func getCurrentVersion() string {
-	return "0.1.0" // TODO: read from config or binary
+	return config.ServerVersion
 }
 
 // FetchVersion fetches the current version from the binary.


### PR DESCRIPTION
fix: remove pre-commit hook installation and fix version detection

remove SetupHooks and RemoveHooks — hook called check-secrets which

does not exist, causing git-courer to spawn as MCP server on every commit

SetupProject no longer installs pre-commit hooks

RemoveProject simplified, no hook cleanup needed

getCurrentVersion now reads config.ServerVersion instead of hardcoded 0.1.0


