### PR TITLE
refactor: annotated git tags with changelog body for vendor-agnostic releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,9 +34,10 @@ checksum:
 
 release:
   prerelease: auto
-  header:
-    from_file:
-      path: .gcourer/changelog-generated.md
+  header: |
+    Changelog
+
+    {{ .TagBody }}
   mode: append
 
 changelog:

--- a/docs/config.md
+++ b/docs/config.md
@@ -100,8 +100,6 @@ Default per-operation values:
 | log_path | string | .gcourer/release.log | Path to release log file |
 | max_log_lines | int | 500 | Max log lines to feed the LLM |
 | max_commits_per_chunk | int | 20 | Max commits per changelog chunk |
-| create_github_release | bool | false | Create GitHub release when creating tags. Set to `false` for vendor-agnostic mode (tag only, let external tools like GoReleaser create releases) |
-| changelog_output_path | string | .gcourer/changelog-generated.md | Path where generated changelog is written for consumption by external release tools |
 
 ### commands
 | Field | Type | Default | Description |
@@ -162,28 +160,23 @@ commit:
 
 ## GoReleaser Integration
 
-git-courer can generate changelogs and write them to disk for consumption by external release tools like GoReleaser.
+git-courer ahora crea tags anotados con el changelog como cuerpo del tag. GoReleaser (o cualquier herramienta CI/CD) lee el changelog directamente desde la anotación del tag usando la variable de template `{{ .TagBody }}`. No requiere archivo auxiliar ni configuración adicional.
 
-### Configuration
-
-1. In `config.yaml`, set `create_github_release: false` (default) to create only tags without GitHub releases.
-
-2. Configure `.goreleaser.yaml` to read the changelog:
+### Example `.goreleaser.yaml`
 
 ```yaml
 # .goreleaser.yaml
 release:
-  draft: false
   prerelease: auto
-  notes_template: |
-    {{ .FileContent ".gcourer/changelog-generated.md" }}
-```
+  header: |
+    Changelog
 
-3. The workflow becomes:
-   - `git-courer release` → creates tag + writes changelog to `.gcourer/changelog-generated.md`
-   - GoReleaser (triggered by tag push) → reads changelog, creates release, uploads binaries
+    {{ .TagBody }}
+```
 
 ### Benefits
 - **Universal compatibility**: Works with any release tool (GoReleaser, release-please, manual scripts)
 - **No vendor lock-in**: git-courer doesn't assume any specific release toolchain
 - **Auto-update compatibility**: Installer works because the release is created by the external tool
+
+

--- a/internal/adapters/git/exec.go
+++ b/internal/adapters/git/exec.go
@@ -298,12 +298,15 @@ func (a *ExecAdapter) Reset(mode string, commit string) (string, error) {
 
 func (a *ExecAdapter) Merge(branch string) (string, error) { return a.runGit("merge", branch) }
 
-func (a *ExecAdapter) Tag(name string) (string, error) {
+func (a *ExecAdapter) Tag(name, message string) (string, error) {
 	if name == "" {
 		return "", fmt.Errorf("tag name is required")
 	}
 	if !domain.IsValidTagName(name) {
 		return "", fmt.Errorf("invalid tag name: %s (use semver like v1.0.0 or 1.0.0)", name)
+	}
+	if message != "" {
+		return a.runGit("tag", "-a", name, "-m", message)
 	}
 	return a.runGit("tag", name)
 }

--- a/internal/adapters/git/exec_test.go
+++ b/internal/adapters/git/exec_test.go
@@ -183,8 +183,8 @@ func TestExecAdapterTag(t *testing.T) {
 	adapter.Add([]string{"initial.txt"})
 	adapter.Commit("Initial commit")
 
-	// Create a tag
-	_, err := adapter.Tag("v1.0.0-test")
+	// Create a lightweight tag (empty message)
+	_, err := adapter.Tag("v1.0.0-test", "")
 	if err != nil {
 		t.Fatalf("Tag() error = %v", err)
 	}
@@ -202,6 +202,59 @@ func TestExecAdapterTag(t *testing.T) {
 	tags, _ := adapter.ListTags()
 	if len(tags) == 0 {
 		t.Error("ListTags() should return created tag")
+	}
+}
+
+// TestExecAdapterTagLightweight verifies Tag with empty message creates a lightweight tag.
+func TestExecAdapterTagLightweight(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0644)
+	adapter := New(dir)
+	adapter.Add([]string{"init.txt"})
+	adapter.Commit("Initial commit")
+
+	_, err := adapter.Tag("v1.0.0-lw", "")
+	if err != nil {
+		t.Fatalf("Tag() error = %v", err)
+	}
+
+	// Verify lightweight tag (no 'tagger' line)
+	out, err := exec.Command("git", "-C", dir, "show", "v1.0.0-lw").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git show tag error = %v, output=%s", err, out)
+	}
+	if containsStr(string(out), "Tagger") {
+		t.Error("lightweight tag should NOT contain 'Tagger' line")
+	}
+}
+
+// TestExecAdapterTagAnnotated verifies Tag with non-empty message creates an annotated tag.
+func TestExecAdapterTagAnnotated(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0644)
+	adapter := New(dir)
+	adapter.Add([]string{"init.txt"})
+	adapter.Commit("Initial commit")
+
+	message := "Release v2.0.0\n\nChangelog\n- feat: new stuff"
+	_, err := adapter.Tag("v2.0.0-ann", message)
+	if err != nil {
+		t.Fatalf("Tag() error = %v", err)
+	}
+
+	out, err := exec.Command("git", "-C", dir, "show", "v2.0.0-ann").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git show tag error = %v, output=%s", err, out)
+	}
+	if !containsStr(string(out), "Tagger") {
+		t.Error("annotated tag should contain 'Tagger' line")
+	}
+	if !containsStr(string(out), "feat: new stuff") {
+		t.Errorf("annotated tag should contain message body, got:\n%s", out)
 	}
 }
 
@@ -503,7 +556,7 @@ func TestLatestTag(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x"), 0644)
 	adapter.Add([]string{"file.txt"})
 	adapter.Commit("tagged commit")
-	adapter.Tag("v2.0.0")
+	adapter.Tag("v2.0.0", "")
 
 	tag, err := adapter.LatestTag()
 	if err != nil {
@@ -525,7 +578,7 @@ func TestCommitsFromTag(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x"), 0644)
 	adapter.Add([]string{"file.txt"})
 	adapter.Commit("base commit")
-	adapter.Tag("v1.0.0")
+	adapter.Tag("v1.0.0", "")
 
 	// More commits after tag
 	os.WriteFile(filepath.Join(dir, "file2.txt"), []byte("y"), 0644)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,9 +112,7 @@ type CommitConfig struct {
 type ReleaseConfig struct {
 	LogPath              string `yaml:"log_path"`                // [USER] Log file path
 	MaxLogLines          int    `yaml:"max_log_lines"`           // [USER] Max log lines
-	MaxCommitsPerChunk   int    `yaml:"max_commits_per_chunk"`   // [USER] Max commits per chunk
-	CreateGitHubRelease  bool   `yaml:"create_github_release"`   // [USER] Create GitHub release using gh CLI
-	ChangelogOutputPath  string `yaml:"changelog_output_path"`   // [USER] File path to write generated changelog
+	MaxCommitsPerChunk int `yaml:"max_commits_per_chunk"` // [USER] Max commits per chunk
 }
 
 // DurationConfig wraps time.Duration for YAML unmarshaling.
@@ -196,11 +194,9 @@ func Default() *Config {
 			MaxLogLines: 500,
 		},
 		Release: ReleaseConfig{
-			LogPath:              ".gcourer/release.log",
-			MaxLogLines:          500,
-			MaxCommitsPerChunk:   20,
-			CreateGitHubRelease:  false,
-			ChangelogOutputPath:  ".gcourer/changelog-generated.md",
+			LogPath:            ".gcourer/release.log",
+			MaxLogLines:        500,
+			MaxCommitsPerChunk: 20,
 		},
 		Commands: CommandsConfig{
 			EnabledOperations: []string{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -416,37 +416,6 @@ func TestDefault_ReleaseConfig(t *testing.T) {
 	}
 }
 
-func TestDefault_ReleaseConfig_NewFields(t *testing.T) {
-	cfg := Default()
-	if cfg.Release.CreateGitHubRelease != false {
-		t.Error("Release.CreateGitHubRelease should be false by default")
-	}
-	if cfg.Release.ChangelogOutputPath != ".gcourer/changelog-generated.md" {
-		t.Errorf("Release.ChangelogOutputPath = %q, want %q", cfg.Release.ChangelogOutputPath, ".gcourer/changelog-generated.md")
-	}
-}
-
-func TestLoadFromDir_OverrideReleaseConfig_NewFields(t *testing.T) {
-	dir := t.TempDir()
-	cfgFile := filepath.Join(dir, ".gcourer", "config.yaml")
-	os.MkdirAll(filepath.Dir(cfgFile), 0755)
-	os.WriteFile(cfgFile, []byte(`release:
-  create_github_release: true
-  changelog_output_path: "custom/changelog.md"
-`), 0644)
-
-	cfg, err := LoadFromDir(dir)
-	if err != nil {
-		t.Fatalf("LoadFromDir() error: %v", err)
-	}
-	if cfg.Release.CreateGitHubRelease != true {
-		t.Errorf("Release.CreateGitHubRelease = %v, want true", cfg.Release.CreateGitHubRelease)
-	}
-	if cfg.Release.ChangelogOutputPath != "custom/changelog.md" {
-		t.Errorf("Release.ChangelogOutputPath = %q, want custom/changelog.md", cfg.Release.ChangelogOutputPath)
-	}
-}
-
 // --- OllamaConfig defaults ---
 
 func TestDefault_OllamaConfig(t *testing.T) {

--- a/internal/core/ports/git.go
+++ b/internal/core/ports/git.go
@@ -52,7 +52,7 @@ type Git interface {
 	DeleteBranch(name string) (string, error)
 	Reset(mode string, commit string) (string, error)
 	Merge(branch string) (string, error)
-	Tag(name string) (string, error)
+	Tag(name, message string) (string, error)
 	DeleteTag(name string) (string, error)
 	DeleteTagRemote(name string) (string, error)
 }

--- a/internal/delivery/mcp/handlers.go
+++ b/internal/delivery/mcp/handlers.go
@@ -206,7 +206,7 @@ func (s *Server) handleGitWrite(_ context.Context, req mcpgo.CallToolRequest) (*
 	case "FETCH":
 		result, err = s.git.Fetch()
 	case "TAG_CREATE":
-		_, err = s.git.Tag(arg)
+		_, err = s.git.Tag(arg, "")
 		if err == nil {
 			s.sendSuccessNotification("tag_create", "Tag created successfully", nil)
 			return mcpgo.NewToolResultText(tagResultJSON("created", arg)), nil
@@ -588,31 +588,27 @@ func (s *Server) handleRelease(_ context.Context, req mcpgo.CallToolRequest, pha
 		}
 
 		changelog, err := s.releaseSvc.LoadChangelog()
-		if err != nil {
-			s.releaseConfirm.RemoveBlocker()
-			s.sendErrorNotification("release", "Failed to load changelog", map[string]any{"error": err.Error()})
-			return mcpgo.NewToolResultError("Failed to load changelog: " + err.Error()), nil
-		}
-
-// Use config from ReleaseService (initialized from config.yaml)
-		// This ensures config-driven behavior by default
-		createGitHubRelease := s.releaseSvc.GetConfig().CreateGitHubRelease
-
-		res, err := s.applyWithBackup("release", false, func() (workflow.Result, error) {
-			output, execErr := s.releaseSvc.Execute(intent, changelog, createGitHubRelease)
-			if execErr != nil {
-				return workflow.Result{}, execErr
+			if err != nil {
+				s.releaseConfirm.RemoveBlocker()
+				s.sendErrorNotification("release", "Failed to load changelog", map[string]any{"error": err.Error()})
+				return mcpgo.NewToolResultError("Failed to load changelog: " + err.Error()), nil
 			}
-			return workflow.Result{
-				Status: workflow.StatusCompleted,
-				Output: output,
-				Summary: &workflow.Summary{
-					Operation: "release",
-					Impact:    "High",
-					Message:   "Release created successfully",
-				},
-			}, nil
-		})
+
+			res, err := s.applyWithBackup("release", false, func() (workflow.Result, error) {
+				output, execErr := s.releaseSvc.Execute(intent, changelog)
+				if execErr != nil {
+					return workflow.Result{}, execErr
+				}
+				return workflow.Result{
+					Status: workflow.StatusCompleted,
+					Output: output,
+					Summary: &workflow.Summary{
+						Operation: "release",
+						Impact:    "High",
+						Message:   "Release created successfully",
+					},
+				}, nil
+			})
 		if err != nil {
 			s.sendErrorNotification("release", "Release execution failed", map[string]any{"error": err.Error()})
 			return mcpgo.NewToolResultError(err.Error()), nil

--- a/internal/delivery/mcp/server.go
+++ b/internal/delivery/mcp/server.go
@@ -85,8 +85,6 @@ func New(cfg *config.Config, git ports.Git, llm ports.LLM, ollamaLifecycle Ollam
 		cfg.Release.MaxCommitsPerChunk,
 		cfg.Release.MaxLogLines,
 		cfg.Release.LogPath,
-		cfg.Release.ChangelogOutputPath,
-		cfg.Release.CreateGitHubRelease, // config-driven: create GH release or let external tools
 	)
 
 	// Create specialized services.

--- a/internal/integration/ollama_flow_test.go
+++ b/internal/integration/ollama_flow_test.go
@@ -215,8 +215,7 @@ func TestReleaseService_Prepare_FullFlow(t *testing.T) {
 	gitAdapter := git.New(dir)
 	llmAdapter := llm.New(LLMHost, LLMModel, LLMApiKey)
 
-	gitAdapter.Tag("v1.0.0")
-	gitAdapter.Tag("v1.0.0")
+	gitAdapter.Tag("v1.0.0", "")
 
 	os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package main\nfunc newFeature() {}\n"), 0644)
 	gitAdapter.Add([]string{"."})
@@ -264,7 +263,7 @@ func TestReleaseService_Generate_Changelog(t *testing.T) {
 	gitAdapter := git.New(dir)
 	llmAdapter := llm.New(LLMHost, LLMModel, LLMApiKey)
 
-	gitAdapter.Tag("v1.0.0")
+	gitAdapter.Tag("v1.0.0", "")
 
 	os.WriteFile(filepath.Join(dir, "a.go"), []byte("package main\n"), 0644)
 	gitAdapter.Add([]string{"."})
@@ -312,7 +311,7 @@ func TestReleaseService_PrepareAndGenerate_EndToEnd(t *testing.T) {
 	gitAdapter := git.New(dir)
 	llmAdapter := llm.New(LLMHost, LLMModel, LLMApiKey)
 
-	gitAdapter.Tag("v1.0.0")
+	gitAdapter.Tag("v1.0.0", "")
 
 	os.WriteFile(filepath.Join(dir, "new.go"), []byte("package main\nfunc new() {}\n"), 0644)
 	gitAdapter.Add([]string{"."})

--- a/internal/workflow/commit_service_test.go
+++ b/internal/workflow/commit_service_test.go
@@ -72,7 +72,7 @@ func (s *stubGit) Reset(mode string, commit string) (string, error) {
 	return "", nil
 }
 func (s *stubGit) Merge(branch string) (string, error) { return "", nil }
-func (s *stubGit) Tag(name string) (string, error)    { return "", nil }
+func (s *stubGit) Tag(name, message string) (string, error) { return "", nil }
 
 type stubLLM struct {
 	chunkMsg    string

--- a/internal/workflow/execute.go
+++ b/internal/workflow/execute.go
@@ -40,7 +40,7 @@ func (w *Workflow) execute(_ context.Context, op string, args map[string]string)
 		return w.git.Pull()
 
 	case "tag_create":
-		return w.git.Tag(args["tag"])
+		return w.git.Tag(args["tag"], "")
 
 	case "tag_delete":
 		return w.git.DeleteTag(args["tag"])

--- a/internal/workflow/prepare_test.go
+++ b/internal/workflow/prepare_test.go
@@ -70,7 +70,7 @@ func (s *stubGitForPrepare) RenameBranch(oldName, newName string) (string, error
 func (s *stubGitForPrepare) DeleteBranch(name string) (string, error)           { return "", nil }
 func (s *stubGitForPrepare) Reset(mode string, commit string) (string, error)   { return "", nil }
 func (s *stubGitForPrepare) Merge(branch string) (string, error)                { return "", nil }
-func (s *stubGitForPrepare) Tag(name string) (string, error)                    { return "", nil }
+func (s *stubGitForPrepare) Tag(name, message string) (string, error)         { return "", nil }
 func (s *stubGitForPrepare) DeleteTag(name string) (string, error)              { return "", nil }
 func (s *stubGitForPrepare) DeleteTagRemote(name string) (string, error)        { return "", nil }
 

--- a/internal/workflow/release.go
+++ b/internal/workflow/release.go
@@ -26,18 +26,16 @@ type ReleaseServiceConfig struct {
 	MaxCommitsPerChunk  int    // max commits per chunk sent to LLM
 	LogPath             string // path to release log file
 	MaxLogLines         int    // circular buffer size for task.log
-	BackgroundThreshold int    // chunks above which run async
-	ChangelogOutputPath string // path to save generated changelog
-	CreateGitHubRelease bool   // create GitHub release via gh CLI (config-driven)
+	BackgroundThreshold int // chunks above which run async
 }
 
 // DefaultReleaseServiceConfig returns sensible defaults derived from Ollama context window.
 func DefaultReleaseServiceConfig(contextWindow, maxCommitsPerChunk, maxLogLines int, logPath string) ReleaseServiceConfig {
-	return DefaultReleaseServiceConfigWithPaths(contextWindow, maxCommitsPerChunk, maxLogLines, logPath, "", false)
+	return DefaultReleaseServiceConfigWithPaths(contextWindow, maxCommitsPerChunk, maxLogLines, logPath)
 }
 
-// DefaultReleaseServiceConfigWithPaths returns config with explicit changelog path.
-func DefaultReleaseServiceConfigWithPaths(contextWindow, maxCommitsPerChunk, maxLogLines int, logPath, changelogOutputPath string, createGHRelease bool) ReleaseServiceConfig {
+// DefaultReleaseServiceConfigWithPaths returns config with explicit log path.
+func DefaultReleaseServiceConfigWithPaths(contextWindow, maxCommitsPerChunk, maxLogLines int, logPath string) ReleaseServiceConfig {
 	cw := contextWindow
 	if cw == 0 {
 		cw = 4096
@@ -47,13 +45,11 @@ func DefaultReleaseServiceConfigWithPaths(contextWindow, maxCommitsPerChunk, max
 		mcc = 20
 	}
 	return ReleaseServiceConfig{
-		ContextWindow:        cw,
-		MaxCommitsPerChunk: mcc,
-		LogPath:            logPath,
-		MaxLogLines:       maxLogLines,
+		ContextWindow:       cw,
+		MaxCommitsPerChunk:  mcc,
+		LogPath:             logPath,
+		MaxLogLines:         maxLogLines,
 		BackgroundThreshold: 3,
-		ChangelogOutputPath: changelogOutputPath,
-		CreateGitHubRelease: createGHRelease, // config-driven
 	}
 }
 
@@ -155,12 +151,11 @@ func (s *ReleaseService) ClearPending() {
 // ReleaseResult holds the outcome of a release operation.
 type ReleaseResult struct {
 	Operation       string   `json:"operation"`
-	TagName         string   `json:"tag_name,omitempty"`
-	Changelog       string   `json:"changelog,omitempty"`
-	IsGitHubRelease bool     `json:"is_github_release,omitempty"`
-	Message         string   `json:"result,omitempty"`
-	Warnings        []string `json:"warnings,omitempty"`
-	Type            string   `json:"type"`
+	TagName   string `json:"tag_name,omitempty"`
+	Changelog string   `json:"changelog,omitempty"`
+	Message   string   `json:"result,omitempty"`
+	Warnings  []string `json:"warnings,omitempty"`
+	Type      string   `json:"type"`
 }
 
 type preparedReleaseState struct {
@@ -422,13 +417,12 @@ func (s *ReleaseService) BuildPreview(intent *domain.ReleaseIntent, changelog st
 	return b.String()
 }
 
-// Execute creates the git tag and optional GitHub release.
+// Execute creates the git tag and pushes it to remote.
 // Includes security checks:
 // - Validate tag with IsValidTagName
 // - Check TagExists before creating
-// - Check IsGHAuthenticated before gh release
-// - Don't ignore gh errors
-func (s *ReleaseService) Execute(intent *domain.ReleaseIntent, changelog string, createGHRelease bool) (string, error) {
+// - Always push tag after creation
+func (s *ReleaseService) Execute(intent *domain.ReleaseIntent, changelog string) (string, error) {
 	s.taskLog.logStart()
 
 	// Security Check 1: Validate tag name
@@ -444,19 +438,12 @@ func (s *ReleaseService) Execute(intent *domain.ReleaseIntent, changelog string,
 		return "", fmt.Errorf("failed to check tag existence: %w", err)
 	}
 	if exists {
-		s.taskLog.logError(fmt.Sprintf("tag already exists: %s", intent.TagName))
+		 s.taskLog.logError(fmt.Sprintf("tag already exists: %s", intent.TagName))
 		return "", fmt.Errorf("tag %s already exists — check the proposed version", intent.TagName)
 	}
-	// Write changelog to disk FIRST (no side effects if fails)
-	if s.cfg.ChangelogOutputPath != "" {
-		if err := s.writeChangelogFile(changelog); err != nil {
-			s.taskLog.logError(fmt.Sprintf("failed to write changelog: %v", err))
-			return "", fmt.Errorf("failed to write changelog: %w", err)
-		}
-	}
 
-	// Create git tag (only after changelog write succeeds)
-	_, err = s.git.Tag(intent.TagName)
+	// Create git tag with changelog annotation
+	_, err = s.git.Tag(intent.TagName, changelog)
 	if err != nil {
 		s.taskLog.logError(fmt.Sprintf("failed to create tag: %v", err))
 		return "", fmt.Errorf("failed to create tag: %w", err)
@@ -464,7 +451,6 @@ func (s *ReleaseService) Execute(intent *domain.ReleaseIntent, changelog string,
 	s.taskLog.logTag(intent.TagName)
 
 	// Push tag to remote — ALWAYS, not optional
-	// If push fails, clean up changelog and fail atomicly
 	_, err = s.git.PushTag(intent.TagName)
 	if err != nil {
 		errStr := err.Error()
@@ -473,72 +459,22 @@ func (s *ReleaseService) Execute(intent *domain.ReleaseIntent, changelog string,
 			s.taskLog.logTag(intent.TagName + " (already remote)")
 		} else {
 			s.taskLog.logError(fmt.Sprintf("failed to push tag: %v", err))
-			// Cleanup: remove written changelog on failure for atomicity
-			if s.cfg.ChangelogOutputPath != "" {
-				_ = os.Remove(s.cfg.ChangelogOutputPath)
-			}
 			return "", fmt.Errorf("failed to push tag: %w", err)
 		}
-	}
-
-	// Optional GitHub release
-	var ghResult string
-	var isGHRelease bool
-	if createGHRelease {
-		// Security Check 3: Check GitHub authentication
-		authenticated, err := s.git.IsGHAuthenticated()
-		if err != nil {
-			s.taskLog.logError(fmt.Sprintf("failed to check GH authentication: %v", err))
-			// Don't ignore GH errors - fail the operation
-			return "", fmt.Errorf("failed to check GH authentication: %w", err)
-		}
-		if !authenticated {
-			s.taskLog.logError("GitHub CLI not authenticated")
-			return "", fmt.Errorf("GitHub CLI not authenticated. Run 'gh auth login' first")
-		}
-
-		// Create GitHub release
-		ghResult, err = s.git.CreateRelease(intent.TagName, changelog)
-		if err != nil {
-			s.taskLog.logError(fmt.Sprintf("failed to create GitHub release: %v", err))
-			// Don't ignore gh errors - the tag was created, but GH release failed
-			return "", fmt.Errorf("git tag created, but GitHub release failed: %w", err)
-		}
-		s.taskLog.logGHRelease(intent.TagName)
-		isGHRelease = true
 	}
 
 	s.taskLog.logDone()
 
 	result := ReleaseResult{
-		Operation:       "release",
-		TagName:         intent.TagName,
-		Changelog:       changelog,
-		IsGitHubRelease: isGHRelease,
-		Type:            "write",
-	}
-
-	if ghResult != "" {
-		result.Message = fmt.Sprintf("Tag %s created%s", intent.TagName, ghResult)
-	} else {
-		result.Message = fmt.Sprintf("Tag %s created", intent.TagName)
+		Operation: "release",
+		TagName:   intent.TagName,
+		Changelog: changelog,
+		Type:      "write",
+		Message:   fmt.Sprintf("Tag %s created", intent.TagName),
 	}
 
 	resp, _ := json.Marshal(result)
 	return string(resp), nil
-}
-
-// writeChangelogFile writes the generated changelog to disk.
-// IMPORTANT: This function silently overwrites the file if it already exists.
-// Back up any important changelog files before invoking the release workflow.
-func (s *ReleaseService) writeChangelogFile(changelog string) error {
-	if err := os.MkdirAll(filepath.Dir(s.cfg.ChangelogOutputPath), 0755); err != nil {
-		return fmt.Errorf("failed to create changelog directory: %w", err)
-	}
-	if err := os.WriteFile(s.cfg.ChangelogOutputPath, []byte(changelog), 0644); err != nil {
-		return fmt.Errorf("failed to write changelog file: %w", err)
-	}
-	return nil
 }
 
 // DetectBranchFlow detects if the repository uses git flow.

--- a/internal/workflow/release_service_test.go
+++ b/internal/workflow/release_service_test.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -66,7 +65,7 @@ func TestReleaseService_Execute_CreatesTag(t *testing.T) {
 		IsRelease:   true,
 	}
 
-	result, err := svc.Execute(intent, "", false)
+	result, err := svc.Execute(intent, "")
 	if err != nil {
 		t.Fatalf("Execute() error: %v", err)
 	}
@@ -90,7 +89,7 @@ func TestReleaseService_Execute_InvalidTagName(t *testing.T) {
 		IsRelease:   true,
 	}
 
-	_, err := svc.Execute(intent, "", false)
+	_, err := svc.Execute(intent, "")
 	if err == nil {
 		t.Error("Execute() should error on invalid tag")
 	}
@@ -107,9 +106,39 @@ func TestReleaseService_Execute_TagAlreadyExists(t *testing.T) {
 		IsRelease:   true,
 	}
 
-	_, err := svc.Execute(intent, "", false)
+	_, err := svc.Execute(intent, "")
 	if err == nil {
 		t.Error("Execute() should error when tag exists")
+	}
+}
+
+// --- Execute passes changelog as tag annotation ---
+
+func TestReleaseService_Execute_PassesChangelogAsTagMessage(t *testing.T) {
+	git := &mockGitForRelease{}
+	llm := &mockLLMForRelease{}
+	svc := newReleaseSvc(t, git, llm)
+
+	intent := &domain.ReleaseIntent{
+		TagName:     "v1.0.0",
+		VersionBump: "minor",
+		IsRelease:   true,
+	}
+	changelog := "## v1.0.0\n- feat: cool stuff"
+
+	_, err := svc.Execute(intent, changelog)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	if !git.tagCalled {
+		t.Error("git.Tag() should have been called")
+	}
+	if git.tagCalledName != "v1.0.0" {
+		t.Errorf("git.Tag() name = %q, want v1.0.0", git.tagCalledName)
+	}
+	if git.tagCalledMessage != changelog {
+		t.Errorf("git.Tag() message = %q, want %q", git.tagCalledMessage, changelog)
 	}
 }
 
@@ -212,322 +241,7 @@ func TestReleaseService_Generate_EmptyInput(t *testing.T) {
 	_ = lines
 }
 
-// --- writeChangelogFile ---
 
-func TestReleaseService_writeChangelogFile_CreatesDirAndWritesContent(t *testing.T) {
-	git := &mockGitForRelease{}
-	llm := &mockLLMForRelease{}
-	dir := t.TempDir()
-	path := filepath.Join(dir, "deep", "changelog.md")
-	cfg := DefaultReleaseServiceConfigWithPaths(4096, 20, 100, filepath.Join(dir, "release.log"), path)
-	chunker := &mockLogChunker{}
-	svc := NewReleaseService(git, llm, chunker, cfg)
-
-	content := "## Changelog v1.0.0\n- feat: initial"
-	if err := svc.writeChangelogFile(content); err != nil {
-		t.Fatalf("writeChangelogFile() error: %v", err)
-	}
-
-	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("expected file to be created at %s: %v", path, err)
-	}
-	if string(got) != content {
-		t.Errorf("file content = %q, want %q", string(got), content)
-	}
-}
-
-func TestReleaseService_writeChangelogFile_OverwritesExisting(t *testing.T) {
-	git := &mockGitForRelease{}
-	llm := &mockLLMForRelease{}
-	dir := t.TempDir()
-	path := filepath.Join(dir, "changelog.md")
-	os.WriteFile(path, []byte("old"), 0644)
-
-	cfg := DefaultReleaseServiceConfigWithPaths(4096, 20, 100, filepath.Join(dir, "release.log"), path)
-	svc := NewReleaseService(git, llm, &mockLogChunker{}, cfg)
-
-	content := "new content"
-	if err := svc.writeChangelogFile(content); err != nil {
-		t.Fatalf("writeChangelogFile() error: %v", err)
-	}
-
-	got, _ := os.ReadFile(path)
-	if string(got) != content {
-		t.Errorf("file content = %q, want %q", string(got), content)
-	}
-}
-
-// --- Execute with changelog output path ---
-
-func TestReleaseService_Execute_WritesChangelogToDisk(t *testing.T) {
-	git := &mockGitForRelease{}
-	llm := &mockLLMForRelease{}
-	dir := t.TempDir()
-	changelogPath := filepath.Join(dir, "out", "CHANGELOG.md")
-	cfg := DefaultReleaseServiceConfig(
-		4096, 20, 100,
-		filepath.Join(dir, "release.log"),
-	)
-	cfg.ChangelogOutputPath = changelogPath
-	chunker := &mockLogChunker{}
-	svc := NewReleaseService(git, llm, chunker, cfg)
-
-	intent := &domain.ReleaseIntent{
-		TagName:     "v1.0.0",
-		VersionBump: "minor",
-		IsRelease:   true,
-	}
-	changelog := "## Added\n- Feature A"
-
-	_, err := svc.Execute(intent, changelog, false)
-	if err != nil {
-		t.Fatalf("Execute() error: %v", err)
-	}
-
-	got, err := os.ReadFile(changelogPath)
-	if err != nil {
-		t.Fatalf("expected changelog file at %s: %v", changelogPath, err)
-	}
-	if string(got) != changelog {
-		t.Errorf("changelog file content = %q, want %q", string(got), changelog)
-	}
-}
-
-func TestReleaseService_Execute_SkipsChangelogWhenNoPath(t *testing.T) {
-	git := &mockGitForRelease{}
-	llm := &mockLLMForRelease{}
-	dir := t.TempDir()
-	cfg := DefaultReleaseServiceConfig(
-		4096, 20, 100,
-		filepath.Join(dir, "release.log"),
-	)
-	cfg.ChangelogOutputPath = "" // empty
-	chunker := &mockLogChunker{}
-	svc := NewReleaseService(git, llm, chunker, cfg)
-
-	intent := &domain.ReleaseIntent{
-		TagName:     "v1.0.0",
-		VersionBump: "minor",
-		IsRelease:   true,
-	}
-
-	_, err := svc.Execute(intent, "irrelevant", false)
-	if err != nil {
-		t.Fatalf("Execute() error: %v", err)
-	}
-}
-
-func TestReleaseService_Execute_createGHReleaseFalse_DoesNotCallCreateRelease(t *testing.T) {
-	git := &mockGitForRelease{
-		isGHAuthenticatedResult: false,
-	}
-
-	llm := &mockLLMForRelease{}
-	dir := t.TempDir()
-	cfg := DefaultReleaseServiceConfig(
-		4096, 20, 100,
-		filepath.Join(dir, "release.log"),
-	)
-	chunker := &mockLogChunker{}
-	svc := NewReleaseService(git, llm, chunker, cfg)
-
-	intent := &domain.ReleaseIntent{
-		TagName:     "v1.0.0",
-		VersionBump: "minor",
-		IsRelease:   true,
-	}
-
-	_, err := svc.Execute(intent, "", false)
-	if err != nil {
-		t.Fatalf("Execute() error: %v", err)
-	}
-
-	// Because createGHRelease is false, IsGHAuthenticated and CreateRelease should never be called
-	if git.isGHAuthenticatedCalled {
-		t.Error("IsGHAuthenticated() should not be called when createGHRelease=false")
-	}
-	if git.createReleaseTag != "" {
-		t.Error("CreateRelease() should not be called when createGHRelease=false")
-	}
-}
-
-func TestReleaseService_Execute_createGHReleaseTrue_CallsCreateRelease(t *testing.T) {
-	var createdTag string
-	var createdChangelog string
-	git := &mockGitForRelease{
-		isGHAuthenticatedResult: true,
-		createReleaseResult: func(tag, changelog string) (string, error) {
-			createdTag = tag
-			createdChangelog = changelog
-			return "", nil
-		},
-	}
-
-	llm := &mockLLMForRelease{}
-	dir := t.TempDir()
-	cfg := DefaultReleaseServiceConfig(
-		4096, 20, 100,
-		filepath.Join(dir, "release.log"),
-	)
-	chunker := &mockLogChunker{}
-	svc := NewReleaseService(git, llm, chunker, cfg)
-
-	intent := &domain.ReleaseIntent{
-		TagName:     "v1.2.0",
-		VersionBump: "minor",
-		IsRelease:   true,
-	}
-	cl := "## Changes"
-
-	_, err := svc.Execute(intent, cl, true)
-	if err != nil {
-		t.Fatalf("Execute() error: %v", err)
-	}
-
-	if !git.isGHAuthenticatedCalled {
-		t.Error("IsGHAuthenticated() should be called when createGHRelease=true")
-	}
-	if createdTag != "v1.2.0" {
-		t.Errorf("CreateRelease tag = %q, want v1.2.0", createdTag)
-	}
-	if createdChangelog != cl {
-		t.Errorf("CreateRelease changelog = %q, want %q", createdChangelog, cl)
-	}
-}
-
-// T2 — IsGHAuthenticated error is returned from service layer.
-func TestReleaseService_Execute_createGHReleaseTrue_IsGHAuthError(t *testing.T) {
-	git := &mockGitForRelease{
-		isGHAuthenticatedResult: false,
-		isGHAuthenticatedErr:  fmt.Errorf("gh not found in PATH"),
-	}
-
-	llm := &mockLLMForRelease{}
-	dir := t.TempDir()
-	cfg := DefaultReleaseServiceConfig(
-		4096, 20, 100,
-		filepath.Join(dir, "release.log"),
-	)
-	chunker := &mockLogChunker{}
-	svc := NewReleaseService(git, llm, chunker, cfg)
-
-	intent := &domain.ReleaseIntent{
-		TagName:     "v1.0.0",
-		VersionBump: "minor",
-		IsRelease:   true,
-	}
-
-	_, err := svc.Execute(intent, "irrelevant", true)
-	if err == nil {
-		t.Fatal("Execute() expected error when IsGHAuthenticated errors, got nil")
-	}
-	if !git.isGHAuthenticatedCalled {
-		t.Error("IsGHAuthenticated() should be called when createGHRelease=true")
-	}
-	if !strings.Contains(err.Error(), "gh not found in PATH") {
-		t.Errorf("error = %q, should wrap original gh error", err.Error())
-	}
-}
-
-// T1 — Atomicity: if changelog write fails, git tag must NOT be created.
-func TestReleaseService_Execute_ChangelogWriteFails_NoTagCreated(t *testing.T) {
-	git := &mockGitForRelease{}
-	llm := &mockLLMForRelease{}
-	// Use a non-existent parent dir that cannot be created (invalid path on most systems)
-	cfg := ReleaseServiceConfig{
-		ContextWindow:       4096,
-		MaxCommitsPerChunk:  20,
-		LogPath:             "/dev/null/release.log", // won't be used
-		MaxLogLines:         10,
-		BackgroundThreshold: 3,
-		ChangelogOutputPath: "/sys/nonexistent/deep/changelog.md", // should fail on mkdir
-	}
-	chunker := &mockLogChunker{}
-	svc := NewReleaseService(git, llm, chunker, cfg)
-
-	intent := &domain.ReleaseIntent{
-		TagName:     "v1.0.0",
-		VersionBump: "minor",
-		IsRelease:   true,
-	}
-
-	_, err := svc.Execute(intent, "irrelevant changelog body", false)
-	if err == nil {
-		t.Fatal("Execute() expected error when changelog write fails, got nil")
-	}
-
-	if git.tagCalled {
-		t.Error("git.Tag() was called even though changelog write failed — atomicity broken")
-	}
-}
-
-func TestReleaseService_Execute_ChangelogWriteSucceeds_TagCreated(t *testing.T) {
-	git := &mockGitForRelease{}
-	llm := &mockLLMForRelease{}
-	dir := t.TempDir()
-	changelogPath := filepath.Join(dir, "CHANGELOG.md")
-	cfg := DefaultReleaseServiceConfig(
-		4096, 20, 100,
-		filepath.Join(dir, "release.log"),
-	)
-	cfg.ChangelogOutputPath = changelogPath
-	chunker := &mockLogChunker{}
-	svc := NewReleaseService(git, llm, chunker, cfg)
-
-	intent := &domain.ReleaseIntent{
-		TagName:     "v2.0.0",
-		VersionBump: "major",
-		IsRelease:   true,
-	}
-
-	_, err := svc.Execute(intent, "## v2.0.0\n- feat: big", false)
-	if err != nil {
-		t.Fatalf("Execute() error: %v", err)
-	}
-
-	if !git.tagCalled {
-		t.Error("git.Tag() was NOT called even though changelog write succeeded")
-	}
-
-	got, err := os.ReadFile(changelogPath)
-	if err != nil {
-		t.Fatalf("expected changelog file to exist: %v", err)
-	}
-	if string(got) != "## v2.0.0\n- feat: big" {
-		t.Errorf("changelog content = %q, want %q", string(got), "## v2.0.0\n- feat: big")
-	}
-}
-
-func TestReleaseService_Execute_PushTagFail_CleansUpChangelog(t *testing.T) {
-	git := &mockGitForRelease{pushTagErr: fmt.Errorf("refused: push would clobber")}
-	llm := &mockLLMForRelease{}
-	dir := t.TempDir()
-	changelogPath := filepath.Join(dir, "CHANGELOG.md")
-	cfg := DefaultReleaseServiceConfig(
-		4096, 20, 100,
-		filepath.Join(dir, "release.log"),
-	)
-	cfg.ChangelogOutputPath = changelogPath
-	chunker := &mockLogChunker{}
-	svc := NewReleaseService(git, llm, chunker, cfg)
-
-	intent := &domain.ReleaseIntent{
-		TagName:     "v2.0.0",
-		VersionBump: "major",
-		IsRelease:   true,
-	}
-
-	_, err := svc.Execute(intent, "## v2.0.0\n- feat: big", false)
-	if err == nil {
-		t.Fatal("Execute() should have returned error when PushTag fails")
-	}
-
-	// Changelog file should be cleaned up (removed) on PushTag failure
-	if _, statErr := os.Stat(changelogPath); !os.IsNotExist(statErr) {
-		t.Errorf("changelog file %s still exists after PushTag failure — cleanup missing", changelogPath)
-	}
-}
 
 func TestReleaseService_Generate_ChunkerError(t *testing.T) {
 	git := &mockGitForRelease{}

--- a/internal/workflow/release_test.go
+++ b/internal/workflow/release_test.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -26,7 +25,8 @@ type mockGitForRelease struct {
 	listBranchesResult      string
 	tagCreated              bool
 	tagCalled               bool
-	changelogResult         string
+	tagCalledName           string
+	tagCalledMessage        string
 	pushTagErr              error
 }
 
@@ -67,7 +67,6 @@ func (m *mockGitForRelease) CreateRelease(tagName, changelog string) (string, er
 	if m.createReleaseResult != nil {
 		return m.createReleaseResult(tagName, changelog)
 	}
-	m.changelogResult = changelog
 	return "", nil
 }
 func (m *mockGitForRelease) CreateBackup(operation string, stashUntracked bool) (domain.Backup, error) {
@@ -90,9 +89,11 @@ func (m *mockGitForRelease) RenameBranch(oldName, newName string) (string, error
 func (m *mockGitForRelease) DeleteBranch(name string) (string, error) { return "", nil }
 func (m *mockGitForRelease) Reset(mode string, commit string) (string, error) { return "", nil }
 func (m *mockGitForRelease) Merge(branch string) (string, error)  { return "", nil }
-func (m *mockGitForRelease) Tag(name string) (string, error) {
+func (m *mockGitForRelease) Tag(name, message string) (string, error) {
 	m.tagCreated = true
 	m.tagCalled = true
+	m.tagCalledName = name
+	m.tagCalledMessage = message
 	return "", nil
 }
 
@@ -234,60 +235,51 @@ func joinLines(lines []string) string {
 	return result
 }
 
-// TestExecute_WritesChangelog verifies that Execute writes the changelog to disk when configured.
-func TestExecute_WritesChangelog(t *testing.T) {
-	tmpDir := t.TempDir()
-	changelogPath := filepath.Join(tmpDir, "changelog.md")
-
+// TestExecute_PassesChangelogToTag verifies that Execute passes the changelog as the tag annotation message.
+func TestExecute_PassesChangelogToTag(t *testing.T) {
 	mockGit := &mockGitForRelease{}
 	mockLLM := &mockLLMForRelease{}
 	mockChunker := &mockLogChunker{}
 
-	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(tmpDir, "release.log"))
-	cfg.ChangelogOutputPath = changelogPath
+	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
 	svc := NewReleaseService(mockGit, mockLLM, mockChunker, cfg)
 
 	intent := &domain.ReleaseIntent{TagName: "v1.2.3"}
 	changelog := "## v1.2.3\n- feat: new stuff"
 
-	_, err := svc.Execute(intent, changelog, false)
+	_, err := svc.Execute(intent, changelog)
 	if err != nil {
-		// writeChangelogFile might succeed but other parts could fail with mock; focus on file presence
+		t.Fatalf("Execute() error = %v", err)
 	}
 
-	got, readErr := os.ReadFile(changelogPath)
-	if readErr != nil {
-		t.Fatalf("expected changelog file at %s, got error: %v", changelogPath, readErr)
+	if !mockGit.tagCalled {
+		t.Fatal("git.Tag() was not called")
 	}
-	if string(got) != changelog {
-		t.Errorf("changelog content = %q, want %q", string(got), changelog)
+	if mockGit.tagCalledName != "v1.2.3" {
+		t.Errorf("git.Tag() name = %q, want v1.2.3", mockGit.tagCalledName)
+	}
+	if mockGit.tagCalledMessage != changelog {
+		t.Errorf("git.Tag() message = %q, want %q", mockGit.tagCalledMessage, changelog)
 	}
 }
 
-// TestWriteChangelogFile_CreatesDirectories verifies that missing directories are created.
-func TestWriteChangelogFile_CreatesDirectories(t *testing.T) {
-	tmpDir := t.TempDir()
-	changelogPath := filepath.Join(tmpDir, "deep", "nested", "changelog.md")
-
+// TestExecute_EmptyChangelogPassesEmptyMessage verifies that Execute passes empty string for changelog when empty.
+func TestExecute_EmptyChangelogPassesEmptyMessage(t *testing.T) {
 	mockGit := &mockGitForRelease{}
 	mockLLM := &mockLLMForRelease{}
 	mockChunker := &mockLogChunker{}
 
-	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(tmpDir, "release.log"))
-	cfg.ChangelogOutputPath = changelogPath
+	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
 	svc := NewReleaseService(mockGit, mockLLM, mockChunker, cfg)
 
-	content := "## Changelog\n- fix: bug"
-	if err := svc.writeChangelogFile(content); err != nil {
-		t.Fatalf("writeChangelogFile() error = %v", err)
+	intent := &domain.ReleaseIntent{TagName: "v1.0.0"}
+	_, err := svc.Execute(intent, "")
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
 	}
 
-	got, err := os.ReadFile(changelogPath)
-	if err != nil {
-		t.Fatalf("expected file at %s, got error: %v", changelogPath, err)
-	}
-	if string(got) != content {
-		t.Errorf("file content = %q, want %q", string(got), content)
+	if mockGit.tagCalledMessage != "" {
+		t.Errorf("git.Tag() message = %q, want empty string", mockGit.tagCalledMessage)
 	}
 }
 
@@ -345,7 +337,7 @@ func TestDetectBranchFlow(t *testing.T) {
 			mockLLM := &mockLLMForRelease{}
 			mockChunker := &mockLogChunker{}
 
-			cfg := DefaultReleaseServiceConfig(4096, 20, 100, "/tmp/release_test.log")
+			cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release_test.log"))
 			svc := NewReleaseService(mockGit, mockLLM, mockChunker, cfg)
 
 			got, err := svc.DetectBranchFlow()
@@ -393,7 +385,7 @@ func TestBuildPreview(t *testing.T) {
 			mockLLM := &mockLLMForRelease{}
 			mockChunker := &mockLogChunker{}
 
-			cfg := DefaultReleaseServiceConfig(4096, 20, 100, "/tmp/release_test.log")
+			cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release_test.log"))
 			svc := NewReleaseService(mockGit, mockLLM, mockChunker, cfg)
 
 			got := svc.BuildPreview(tt.intent, tt.changelog)

--- a/test/e2e/workflow_test.go
+++ b/test/e2e/workflow_test.go
@@ -30,48 +30,56 @@ type mockGit struct {
 }
 
 func (m *mockGit) Status() (domain.Status, error)                { return domain.Status{}, nil }
-func (m *mockGit) Diff(paths ...string) (string, error)      { return "", nil }
-func (m *mockGit) DiffStaged(paths ...string) (string, error) { return "diff --git a/f.go", nil }
-func (m *mockGit) ListUntracked() ([]string, error)       { return nil, nil }
-func (m *mockGit) Log(limit int, paths ...string) (string, error)   { return m.commitsResult, nil }
-func (m *mockGit) LogFull(limit int) (string, error)      { return m.commitsResult, nil }
-func (m *mockGit) CurrentBranch() (string, error)       { return "develop", nil }
-func (m *mockGit) ListBranches(pattern ...string) (string, error) { return m.listBranchesResult, nil }
+func (m *mockGit) Diff(paths ...string) (string, error)          { return "", nil }
+func (m *mockGit) DiffStaged(paths ...string) (string, error)    { return "diff --git a/f.go", nil }
+func (m *mockGit) ListUntracked() ([]string, error)              { return nil, nil }
+func (m *mockGit) Log(limit int, paths ...string) (string, error) { return m.commitsResult, nil }
+func (m *mockGit) LogFull(limit int) (string, error)             { return m.commitsResult, nil }
+func (m *mockGit) CurrentBranch() (string, error)                { return "develop", nil }
+func (m *mockGit) ListBranches(pattern ...string) (string, error) {
+	return m.listBranchesResult, nil
+}
 func (m *mockGit) ListTags(pattern ...string) ([]string, error) { return m.listTagsResult, nil }
-func (m *mockGit) IsRepo() bool                        { return true }
-func (m *mockGit) LatestTag() (string, error)          { return m.latestTagResult, nil }
-func (m *mockGit) CommitsFromTag(sinceTag string) (string, error) { return m.commitsResult, nil }
-func (m *mockGit) TagExists(name string) (bool, error)  { return m.tagExistsResult, nil }
-func (m *mockGit) DeleteTag(name string) (string, error) { return "", nil }
+func (m *mockGit) IsRepo() bool                                 { return true }
+func (m *mockGit) LatestTag() (string, error)                   { return m.latestTagResult, nil }
+func (m *mockGit) CommitsFromTag(sinceTag string) (string, error) {
+	return m.commitsResult, nil
+}
+func (m *mockGit) TagExists(name string) (bool, error)     { return m.tagExistsResult, nil }
+func (m *mockGit) DeleteTag(name string) (string, error)  { return "", nil }
 func (m *mockGit) DeleteTagRemote(name string) (string, error) { return "", nil }
-func (m *mockGit) PushTag(name string) (string, error) { return "", nil }
-func (m *mockGit) PushTags() (string, error) { return "", nil }
-func (m *mockGit) IsGHAuthenticated() (bool, error)     { return false, nil }
-func (m *mockGit) CreateRelease(tagName, changelog string) (string, error) { return "", nil }
+func (m *mockGit) PushTag(name string) (string, error)    { return "", nil }
+func (m *mockGit) PushTags() (string, error)              { return "", nil }
+func (m *mockGit) IsGHAuthenticated() (bool, error)       { return false, nil }
+func (m *mockGit) CreateRelease(tagName, changelog string) (string, error) {
+	return "", nil
+}
 func (m *mockGit) CreateBackup(operation string, stashUntracked bool) (domain.Backup, error) {
 	return domain.Backup{}, nil
 }
 func (m *mockGit) RestoreBackup(backup domain.Backup) error { return nil }
 func (m *mockGit) DeleteBackup(backup domain.Backup) error { return nil }
-func (m *mockGit) Add(paths []string) error             { return nil }
-func (m *mockGit) Remove(paths []string) error          { return nil }
-func (m *mockGit) Checkout(name string) (string, error) { return "", nil }
-func (m *mockGit) Switch(name string) error            { return nil }
-func (m *mockGit) Push() (string, error)               { return "", nil }
-func (m *mockGit) Pull() (string, error)               { return "", nil }
-func (m *mockGit) Fetch() (string, error)              { return "", nil }
-func (m *mockGit) Stash() (string, error)              { return "", nil }
-func (m *mockGit) StashPop() (string, error)          { return "", nil }
+func (m *mockGit) Add(paths []string) error               { return nil }
+func (m *mockGit) Remove(paths []string) error            { return nil }
+func (m *mockGit) Checkout(name string) (string, error)   { return "", nil }
+func (m *mockGit) Switch(name string) error                 { return nil }
+func (m *mockGit) Push() (string, error)                  { return "", nil }
+func (m *mockGit) Pull() (string, error)                  { return "", nil }
+func (m *mockGit) Fetch() (string, error)                 { return "", nil }
+func (m *mockGit) Stash() (string, error)               { return "", nil }
+func (m *mockGit) StashPop() (string, error)             { return "", nil }
 func (m *mockGit) Commit(message string) (string, error) {
 	m.commitCalled = true
 	return "abc1234", nil
 }
-func (m *mockGit) Branch(name string) (string, error)   { return "", nil }
-func (m *mockGit) RenameBranch(oldName, newName string) (string, error) { return "", nil }
+func (m *mockGit) Branch(name string) (string, error) { return "", nil }
+func (m *mockGit) RenameBranch(oldName, newName string) (string, error) {
+	return "", nil
+}
 func (m *mockGit) DeleteBranch(name string) (string, error) { return "", nil }
 func (m *mockGit) Reset(mode string, commit string) (string, error) { return "", nil }
-func (m *mockGit) Merge(branch string) (string, error) { return "", nil }
-func (m *mockGit) Tag(name string) (string, error) {
+func (m *mockGit) Merge(branch string) (string, error)    { return "", nil }
+func (m *mockGit) Tag(name, message string) (string, error) {
 	m.tagCalled = true
 	m.tagCalledWith = name
 	return "", nil
@@ -175,7 +183,7 @@ func TestExistingTagReturnsError(t *testing.T) {
 	svc := workflow.NewReleaseService(git, llm, chunker, cfg)
 
 	intent := &domain.ReleaseIntent{TagName: "v1.0.0", IsRelease: true}
-	_, err := svc.Execute(intent, "## Changelog", false)
+	_, err := svc.Execute(intent, "## Changelog")
 	if err == nil {
 		t.Fatal("Execute() expected error for existing tag, got nil")
 	}
@@ -190,7 +198,7 @@ func TestExistingTagReturnsError(t *testing.T) {
 // --- Test 3: RELEASE_APPLY goroutine error is surfaced via LoadState ---
 
 func TestReleaseStateErrorIsPropagated(t *testing.T) {
-	cfg := workflow.DefaultReleaseServiceConfigWithPaths(4096, 20, 50, tempLogPath(t), "")
+	cfg := workflow.DefaultReleaseServiceConfigWithPaths(4096, 20, 50, tempLogPath(t))
 
 	git := &mockGit{}
 	llm := &mockLLM{}
@@ -227,10 +235,7 @@ func TestReleaseFullFlow(t *testing.T) {
 	}
 	chunker := &mockLogChunker{}
 
-	dir := t.TempDir()
-	cfg := workflow.DefaultReleaseServiceConfigWithPaths(4096, 20, 50, tempLogPath(t),
-		filepath.Join(dir, "changelog.md"),
-	)
+	cfg := workflow.DefaultReleaseServiceConfigWithPaths(4096, 20, 50, tempLogPath(t))
 	svc := workflow.NewReleaseService(git, llm, chunker, cfg)
 
 	intent, commits, _, err := svc.Prepare("release version 1.1.0", "")
@@ -252,7 +257,7 @@ func TestReleaseFullFlow(t *testing.T) {
 		t.Error("Generate() returned empty changelog")
 	}
 
-	_, err = svc.Execute(intent, changelog, false)
+	_, err = svc.Execute(intent, changelog)
 	if err != nil {
 		t.Fatalf("Execute() error: %v", err)
 	}
@@ -307,10 +312,7 @@ func TestPreviousTagSemverOrdering(t *testing.T) {
 	}
 	chunker := &mockLogChunker{}
 
-	dir := t.TempDir()
-	cfg := workflow.DefaultReleaseServiceConfigWithPaths(4096, 20, 50, tempLogPath(t),
-		filepath.Join(dir, "changelog.md"),
-	)
+	cfg := workflow.DefaultReleaseServiceConfigWithPaths(4096, 20, 50, tempLogPath(t))
 	svc := workflow.NewReleaseService(git, llm, chunker, cfg)
 
 	intent, _, _, err := svc.Prepare("bump minor", "")


### PR DESCRIPTION
## Summary

- `Tag(name string)` → `Tag(name, message string)`: git tags now carry the generated changelog as annotation body
- GoReleaser reads `{{ .TagBody }}` directly from annotated tags — no file workaround needed
- Removed deprecated config fields: `CreateGitHubRelease`, `ChangelogOutputPath` (obsoleted by tag annotation approach)
- All tests passing (`go test ./...`, `go test -race ./...`)

## Changes

| File | Change |
|------|--------|
| `internal/core/ports/git.go` | `Tag(name, message string)` signature |
| `internal/adapters/git/exec.go` | Annotated tag creation with `git tag -a -m` |
| `internal/workflow/release.go` | Pass changelog to Tag(), remove `writeChangelogFile`, remove `CreateGitHubRelease` block |
| `internal/config/config.go` | Remove `CreateGitHubRelease`, `ChangelogOutputPath` fields |
| `.goreleaser.yaml` | `release: header: "{{ .TagBody }}"` |
| `docs/config.md` | Updated GoReleaser integration docs |

## Test Plan

- [x] `go test ./...` passes (17 packages, 0 failures)
- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean
- [x] Build compiles successfully
- [x] All mock/stub signatures updated