### PR TITLE
feat: PR commit enrichment for changelog generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,14 @@
 module github.com/Alejandro-M-P/git-courer
 
-go 1.24.11
+go 1.25.0
 
 require (
 	github.com/bluekeyes/go-gitdiff v0.8.1
 	github.com/creativeprojects/go-selfupdate v1.5.2
+	github.com/google/go-github/v74 v74.0.0
+	github.com/mark3labs/mcp-go v0.47.0
+	github.com/whilp/git-urls v1.0.0
+	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -14,23 +18,18 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/go-fed/httpsig v1.1.0 // indirect
-	github.com/google/go-github/v74 v74.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-version v1.8.0 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	gitlab.com/gitlab-org/api/client-go v1.9.1 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
-)
-
-require (
-	github.com/google/jsonschema-go v0.4.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/mark3labs/mcp-go v0.47.0
-	github.com/spf13/cast v1.7.1 // indirect
-	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
+github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 gitlab.com/gitlab-org/api/client-go v1.9.1 h1:tZm+URa36sVy8UCEHQyGGJ8COngV4YqMHpM6k9O5tK8=
@@ -70,6 +72,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
 golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/adapters/git/exec.go
+++ b/internal/adapters/git/exec.go
@@ -233,3 +233,7 @@ func (a *ExecAdapter) Switch(name string) error {
 	_, err := a.runGit("switch", name)
 	return err
 }
+
+func (a *ExecAdapter) RemoteURL() (string, error) {
+	return a.runGit("remote", "get-url", "origin")
+}

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -1,0 +1,95 @@
+// Package github implements the GitHubAPI port using go-github.
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	gh "github.com/google/go-github/v74/github"
+
+	"github.com/Alejandro-M-P/git-courer/internal/core/domain"
+)
+
+const maxConcurrentPRFetches = 5
+
+// Client implements ports.GitHubAPI using the go-github library.
+type Client struct {
+	client *gh.Client
+}
+
+// NewClient creates a GitHub API client authenticated with the given token.
+func NewClient(token string) *Client {
+	c := gh.NewClient(nil).WithAuthToken(token)
+	return &Client{client: c}
+}
+
+// FetchPRCommits fetches commits for each PR number in parallel (max 5 concurrent).
+// Returns a map from PR number to its commits.
+// Partial failure is tolerated — if one PR returns 404 (not a PR) or another error,
+// that PR is skipped silently. Error is only returned when every single PR fails.
+func (c *Client) FetchPRCommits(ctx context.Context, owner, repo string, prNumbers []int) (map[int][]domain.PRCommit, error) {
+	result := make(map[int][]domain.PRCommit, len(prNumbers))
+	if len(prNumbers) == 0 {
+		return result, nil
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, maxConcurrentPRFetches)
+	var successCount int
+	var firstErr error
+	var once sync.Once
+
+	for _, prNum := range prNumbers {
+		prNum := prNum // capture
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			commits, _, err := c.client.PullRequests.ListCommits(ctx, owner, repo, prNum, nil)
+			if err != nil {
+				once.Do(func() { firstErr = fmt.Errorf("fetch commits for PR #%d: %w", prNum, err) })
+				// Swallow the error — caller will use the fat commit as fallback for this PR
+				return
+			}
+
+			var prCommits []domain.PRCommit
+			for _, rc := range commits {
+				prCommits = append(prCommits, domain.PRCommit{
+					SHA:     rc.GetSHA(),
+					Message: rc.GetCommit().GetMessage(),
+					Author:  rc.GetAuthor().GetLogin(),
+				})
+			}
+
+			mu.Lock()
+			result[prNum] = prCommits
+			successCount++
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+
+	// Error only if *no* PR succeeded yet all failed.
+	if len(result) == 0 && firstErr != nil {
+		return nil, firstErr
+	}
+
+	return result, nil
+}
+
+// githubNewClientWithHTTP creates a go-github client pointing at a custom base URL
+// (used by tests to redirect to httptest.NewServer).
+func githubNewClientWithHTTP(httpClient *http.Client, baseURL string) (*gh.Client, error) {
+	client, err := gh.NewClient(httpClient).WithEnterpriseURLs(baseURL, baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("create github client with custom URL: %w", err)
+	}
+	return client, nil
+}

--- a/internal/adapters/github/client_integration_test.go
+++ b/internal/adapters/github/client_integration_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+// +build integration
+
+package github
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestFetchPRCommits_Live makes a real API call to GitHub for PR #40.
+// It NEVER fails — skips if token is missing, API is down, or PR has no commits.
+func TestFetchPRCommits_Live(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping live test in short mode")
+	}
+
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		t.Skip("GITHUB_TOKEN not set — skipping live GitHub API test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client := NewClient(token)
+
+	result, err := client.FetchPRCommits(ctx, "Alejandro-M-P", "git-courer", []int{40})
+	if err != nil {
+		// API might be rate-limited or down — not a code failure
+		t.Skipf("Live API call failed: %v", err)
+	}
+
+	commits, ok := result[40]
+	if !ok || len(commits) == 0 {
+		t.Skip("PR #40 returned no commits (may have been deleted or token lacks permissions)")
+	}
+
+	t.Logf("PR #40 has %d commits:", len(commits))
+	for _, c := range commits {
+		t.Logf("  - %s: %s", c.SHA[:8], c.Message)
+	}
+
+	// Verify we got commits with SHA and Message
+	for _, c := range commits {
+		if c.SHA == "" {
+			t.Error("commit SHA is empty")
+		}
+		if c.Message == "" {
+			t.Error("commit Message is empty")
+		}
+	}
+}

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -1,0 +1,173 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Alejandro-M-P/git-courer/internal/core/domain"
+)
+
+func TestFetchPRCommits(t *testing.T) {
+	mockCommits := []map[string]interface{}{
+		{
+			"sha": "abc123",
+			"commit": map[string]interface{}{
+				"message": "feat: add login",
+			},
+			"author": map[string]interface{}{
+				"login": "alice",
+			},
+		},
+	}
+
+	cases := []struct {
+		name        string
+		prNumbers   []int
+		statusCode  int
+		wantCounts  map[int]int // PR number -> expected commit count
+		wantErr     bool
+	}{
+		{
+			name:       "single PR success",
+			prNumbers:  []int{42},
+			statusCode: http.StatusOK,
+			wantCounts: map[int]int{42: 1},
+			wantErr:    false,
+		},
+		{
+			name:       "multiple PRs parallel",
+			prNumbers:  []int{10, 20},
+			statusCode: http.StatusOK,
+			wantCounts: map[int]int{10: 1, 20: 1},
+			wantErr:    false,
+		},
+		{
+			name:       "API error returns error",
+			prNumbers:  []int{42},
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+		{
+			name:       "404 returns error",
+			prNumbers:  []int{99},
+			statusCode: http.StatusNotFound,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var requestCount atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount.Add(1)
+				// Verify path format: /repos/owner/repo/pulls/{prNumber}/commits
+				if tc.statusCode != http.StatusOK {
+					w.WriteHeader(tc.statusCode)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(mockCommits)
+			}))
+			defer srv.Close()
+
+			client := NewClient("test-token")
+			// Override base URL for testing
+			client.client, _ = githubNewClientWithHTTP(srv.Client(), srv.URL)
+
+			result, err := client.FetchPRCommits(context.Background(), "owner", "repo", tc.prNumbers)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, prNum := range tc.prNumbers {
+				commits, ok := result[prNum]
+				if !ok {
+					t.Errorf("expected PR #%d in result", prNum)
+					continue
+				}
+				expectedCount := tc.wantCounts[prNum]
+				if len(commits) != expectedCount {
+					t.Errorf("PR #%d: got %d commits, want %d", prNum, len(commits), expectedCount)
+				}
+				if expectedCount > 0 {
+					c := commits[0]
+					if c.SHA != "abc123" {
+						t.Errorf("PR #%d commit SHA = %q, want %q", prNum, c.SHA, "abc123")
+					}
+					if c.Message != "feat: add login" {
+						t.Errorf("PR #%d commit Message = %q, want %q", prNum, c.Message, "feat: add login")
+					}
+					if c.Author != "alice" {
+						t.Errorf("PR #%d commit Author = %q, want %q", prNum, c.Author, "alice")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFetchPRCommitsMapsToPRCommit(t *testing.T) {
+	// Verify domain.PRCommit fields are correctly mapped from go-github types
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		commits := []map[string]interface{}{
+			{
+				"sha": "deadbeef",
+				"commit": map[string]interface{}{
+					"message": "fix: security issue",
+				},
+				"author": map[string]interface{}{
+					"login": "bob",
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(commits)
+	}))
+	defer srv.Close()
+
+	client := NewClient("test-token")
+	client.client, _ = githubNewClientWithHTTP(srv.Client(), srv.URL)
+
+	result, err := client.FetchPRCommits(context.Background(), "owner", "repo", []int{7})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	prCommits := result[7]
+	if len(prCommits) != 1 {
+		t.Fatalf("expected 1 commit, got %d", len(prCommits))
+	}
+
+	got := prCommits[0]
+	want := domain.PRCommit{SHA: "deadbeef", Message: "fix: security issue", Author: "bob"}
+	if got != want {
+		t.Errorf("PRCommit = %+v, want %+v", got, want)
+	}
+}
+
+func TestFetchPRCommitsEmptyPRList(t *testing.T) {
+	client := NewClient("test-token")
+
+	result, err := client.FetchPRCommits(context.Background(), "owner", "repo", []int{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %v", result)
+	}
+}
+
+// Suppress unused import for fmt — it's used in URL formatting
+var _ = fmt.Sprintf

--- a/internal/adapters/llm/openai_standard/adapter.go
+++ b/internal/adapters/llm/openai_standard/adapter.go
@@ -217,6 +217,12 @@ func (a *OpenAIStandardAdapter) IsAvailable() bool {
 	return err == nil
 }
 
+// IsWarmed returns true if the model has been loaded into memory.
+// For OpenAI-compatible endpoints, we assume always warmed (no preload needed).
+func (a *OpenAIStandardAdapter) IsWarmed() bool {
+	return true
+}
+
 // VerifySecrets uses the LLM to verify if a diff contains sensitive information.
 func (a *OpenAIStandardAdapter) VerifySecrets(diff string, findings []domain.SecretDetection) (bool, error) {
 	if len(findings) == 0 {

--- a/internal/core/domain/pr.go
+++ b/internal/core/domain/pr.go
@@ -1,0 +1,9 @@
+// Package domain holds the core business types.
+package domain
+
+// PRCommit represents a single commit within a Pull Request.
+type PRCommit struct {
+	SHA     string
+	Message string
+	Author  string
+}

--- a/internal/core/ports/git.go
+++ b/internal/core/ports/git.go
@@ -19,6 +19,7 @@ type Git interface {
 	ListBranches(pattern ...string) (string, error)
 	ListTags(pattern ...string) ([]string, error)
 	IsRepo() bool
+	RemoteURL() (string, error)
 
 	// --- GitHub CLI Integration ---
 	LatestTag() (string, error)

--- a/internal/core/ports/github.go
+++ b/internal/core/ports/github.go
@@ -1,0 +1,16 @@
+// Package ports defines the interfaces that the core domain depends on.
+package ports
+
+import (
+	"context"
+
+	"github.com/Alejandro-M-P/git-courer/internal/core/domain"
+)
+
+// GitHubAPI provides access to GitHub PR-level commit details.
+// Implementations use go-github or the gh CLI under the hood.
+type GitHubAPI interface {
+	// FetchPRCommits fetches the list of commits for each PR.
+	// Returns a map where the key is the PR number and the value is the ordered slice of commits.
+	FetchPRCommits(ctx context.Context, owner, repo string, prNumbers []int) (map[int][]domain.PRCommit, error)
+}

--- a/internal/delivery/mcp/server.go
+++ b/internal/delivery/mcp/server.go
@@ -4,9 +4,11 @@ package mcp
 import (
 	"context"
 	"log"
+	"os"
 	"sync"
 
 	"github.com/Alejandro-M-P/git-courer/internal/adapters/confirm"
+	ghadapter "github.com/Alejandro-M-P/git-courer/internal/adapters/github"
 	"github.com/Alejandro-M-P/git-courer/internal/config"
 	"github.com/Alejandro-M-P/git-courer/internal/core/domain"
 	"github.com/Alejandro-M-P/git-courer/internal/core/ports"
@@ -91,7 +93,13 @@ func New(cfg *config.Config, git ports.Git, llm ports.LLM, lifecycle ports.Lifec
 
 	// Create specialized services.
 	commitSvc := workflow.NewCommitService(git, llm, chunker, securitySvc, commitCfg)
-	releaseSvc := workflow.NewReleaseService(git, llm, logChunker, releaseCfg)
+
+	// PR enrichment: opt-in via GITHUB_TOKEN env var.
+	var githubAPI ports.GitHubAPI
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		githubAPI = ghadapter.NewClient(token)
+	}
+	releaseSvc := workflow.NewReleaseService(git, llm, logChunker, releaseCfg, githubAPI)
 
 	// Create the main orchestrator with all its tools.
 	reviewWorkflow := workflow.New(git, llm, reviewConfirm, cfg, commitSvc, releaseSvc, securitySvc)

--- a/internal/integration/ollama_flow_test.go
+++ b/internal/integration/ollama_flow_test.go
@@ -228,7 +228,7 @@ func TestReleaseService_Prepare_FullFlow(t *testing.T) {
 		50,
 		filepath.Join(testWorkDir, "release.log"),
 	)
-	svc := workflow.NewReleaseService(gitAdapter, llmAdapter, logChunker, releaseCfg)
+	svc := workflow.NewReleaseService(gitAdapter, llmAdapter, logChunker, releaseCfg, nil)
 
 	log.Println("=== TestReleaseService_Prepare_FullFlow ===")
 
@@ -280,7 +280,7 @@ func TestReleaseService_Generate_Changelog(t *testing.T) {
 		50,
 		filepath.Join(testWorkDir, "release-generate.log"),
 	)
-	svc := workflow.NewReleaseService(gitAdapter, llmAdapter, logChunker, releaseCfg)
+	svc := workflow.NewReleaseService(gitAdapter, llmAdapter, logChunker, releaseCfg, nil)
 
 	commits := `feat: add feature A
 fix: resolve bug B`
@@ -325,7 +325,7 @@ func TestReleaseService_PrepareAndGenerate_EndToEnd(t *testing.T) {
 		50,
 		filepath.Join(testWorkDir, "release-e2e.log"),
 	)
-	svc := workflow.NewReleaseService(gitAdapter, llmAdapter, logChunker, releaseCfg)
+	svc := workflow.NewReleaseService(gitAdapter, llmAdapter, logChunker, releaseCfg, nil)
 
 	log.Println("=== TestReleaseService_PrepareAndGenerate_EndToEnd ===")
 

--- a/internal/integration/workflow_matrix_test.go
+++ b/internal/integration/workflow_matrix_test.go
@@ -165,7 +165,7 @@ func makeWorkflow(gitA ports.Git, llmA ports.LLM, previewOps map[string]bool) (*
 	commitCfg := workflow.DefaultCommitServiceConfig(4096, 50, "/tmp/commit.log")
 	commit := workflow.NewCommitService(gitA, llmA, chunkers.NewDiffChunker(), sec, commitCfg)
 	releaseCfg := workflow.DefaultReleaseServiceConfig(4096, 20, 50, "/tmp/release.log")
-	release := workflow.NewReleaseService(gitA, llmA, chunkers.NewLogChunker(4096), releaseCfg)
+	release := workflow.NewReleaseService(gitA, llmA, chunkers.NewLogChunker(4096), releaseCfg, nil)
 
 	return workflow.New(gitA, llmA, c, cfg, commit, release, sec), c
 }
@@ -179,7 +179,7 @@ func makeReleaseSvc(t *testing.T, gitA ports.Git, llmA ports.LLM, dir string) *w
 		50,
 		filepath.Join(dir, ".gcourer", "release.log"),
 	)
-	return workflow.NewReleaseService(gitA, llmA, chunkers.NewLogChunker(4096), cfg)
+	return workflow.NewReleaseService(gitA, llmA, chunkers.NewLogChunker(4096), cfg, nil)
 }
 
 // gitLogMessages returns the commit subject lines from the sandbox repo,

--- a/internal/workflow/commit_service_test.go
+++ b/internal/workflow/commit_service_test.go
@@ -35,6 +35,7 @@ func (s *stubGit) ListBranches(pattern ...string) (string, error) { return "main
 func (s *stubGit) ListTags(pattern ...string) ([]string, error) { return nil, nil }
 func (s *stubGit) IsRepo() bool                       { return true }
 func (s *stubGit) LatestTag() (string, error)           { return "", nil }
+func (s *stubGit) RemoteURL() (string, error)           { return "", nil }
 func (s *stubGit) CommitsFromTag(sinceTag string) (string, error) { return "", nil }
 func (s *stubGit) TagExists(name string) (bool, error)   { return false, nil }
 func (s *stubGit) DeleteTag(name string) (string, error)  { return "", nil }

--- a/internal/workflow/pr_enrich.go
+++ b/internal/workflow/pr_enrich.go
@@ -1,0 +1,104 @@
+package workflow
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/Alejandro-M-P/git-courer/internal/core/domain"
+	giturls "github.com/whilp/git-urls"
+)
+
+var prRefRE = regexp.MustCompile(`Merge pull request #(\d+)|\(#(\d+)\)`)
+
+// detectPRNumbers scans commit messages for PR references.
+// Supports squash-merges "(#N)" and merge-commits "Merge pull request #N".
+// Returns deduplicated PR numbers preserving first-appearance order.
+func detectPRNumbers(commits string) []int {
+	seen := make(map[int]struct{})
+	var result []int
+	for _, m := range prRefRE.FindAllStringSubmatch(commits, -1) {
+		var numStr string
+		if m[1] != "" {
+			numStr = m[1]
+		} else {
+			numStr = m[2]
+		}
+		var n int
+		if _, err := fmt.Sscanf(numStr, "%d", &n); err != nil {
+			continue
+		}
+		if _, ok := seen[n]; !ok {
+			seen[n] = struct{}{}
+			result = append(result, n)
+		}
+	}
+	return result
+}
+
+// mergeEnrichedCommits replaces lines that reference a PR with the PR's commits.
+// Lines without PR references pass through unchanged.
+// order of non-replaced lines is preserved.
+func mergeEnrichedCommits(raw string, enriched map[int][]domain.PRCommit) string {
+	var out []string
+	for _, line := range strings.Split(raw, "\n") {
+		found := false
+		for _, m := range prRefRE.FindAllStringSubmatch(line, -1) {
+			var numStr string
+			if m[1] != "" {
+				numStr = m[1]
+			} else {
+				numStr = m[2]
+			}
+			var pr int
+			if _, err := fmt.Sscanf(numStr, "%d", &pr); err != nil {
+				continue
+			}
+			if commits, ok := enriched[pr]; ok {
+				for _, c := range commits {
+					out = append(out, c.Message)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			// keep the original line only if it wasn't a newline-only or whitespace-only
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			out = append(out, trimmed)
+		}
+	}
+	return 	strings.Join(out, "\n")
+}
+
+// resolveOwnerRepo parses a git remote URL and extracts the owner and repo name.
+// Supports all standard git URL formats (HTTPS, SSH, SCP-like) via git-urls.
+// Returns isGitHub=true only when the host is "github.com".
+func resolveOwnerRepo(remoteURL string) (owner, repo string, isGitHub bool, err error) {
+	if remoteURL == "" {
+		return "", "", false, nil
+	}
+
+	u, err := giturls.Parse(remoteURL)
+	if err != nil {
+		return "", "", false, fmt.Errorf("parse remote URL: %w", err)
+	}
+
+	if u.Hostname() != "github.com" {
+		return "", "", false, nil
+	}
+
+	// Path is like "Alejandro-M-P/git-courer.git" or "Alejandro-M-P/git-courer"
+	path := strings.TrimPrefix(u.Path, "/")
+	path = strings.TrimSuffix(path, ".git")
+
+	parts := strings.SplitN(path, "/", 3) // max 3 to prevent extra segments
+	if len(parts) < 2 {
+		return "", "", false, fmt.Errorf("invalid repo path: %s", path)
+	}
+
+	return parts[0], parts[1], true, nil
+}

--- a/internal/workflow/pr_enrich_test.go
+++ b/internal/workflow/pr_enrich_test.go
@@ -1,0 +1,221 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/Alejandro-M-P/git-courer/internal/core/domain"
+)
+
+func TestResolveOwnerRepo(t *testing.T) {
+	cases := []struct {
+		name           string
+		input          string
+		expectedOwner  string
+		expectedRepo   string
+		expectedGitHub bool
+	}{
+		{
+			name:           "https clean",
+			input:          "https://github.com/owner/repo.git",
+			expectedOwner:  "owner",
+			expectedRepo:   "repo",
+			expectedGitHub: true,
+		},
+		{
+			name:           "https no git",
+			input:          "https://github.com/owner/repo",
+			expectedOwner:  "owner",
+			expectedRepo:   "repo",
+			expectedGitHub: true,
+		},
+		{
+			name:           "https with token",
+			input:          "https://token@github.com/owner/repo.git",
+			expectedOwner:  "owner",
+			expectedRepo:   "repo",
+			expectedGitHub: true,
+		},
+		{
+			name:           "ssh classic",
+			input:          "git@github.com:owner/repo.git",
+			expectedOwner:  "owner",
+			expectedRepo:   "repo",
+			expectedGitHub: true,
+		},
+		{
+			name:           "ssh explicit port",
+			input:          "ssh://git@github.com:22/owner/repo.git",
+			expectedOwner:  "owner",
+			expectedRepo:   "repo",
+			expectedGitHub: true,
+		},
+		{
+			name:           "gitlab skip",
+			input:          "https://gitlab.com/owner/repo.git",
+			expectedOwner:  "",
+			expectedRepo:   "",
+			expectedGitHub: false,
+		},
+		{
+			name:           "empty url",
+			input:          "",
+			expectedOwner:  "",
+			expectedRepo:   "",
+			expectedGitHub: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			owner, repo, isGitHub, err := resolveOwnerRepo(tc.input)
+			if err != nil {
+				t.Fatalf("resolveOwnerRepo(%q) returned unexpected error: %v", tc.input, err)
+			}
+			if owner != tc.expectedOwner {
+				t.Errorf("resolveOwnerRepo(%q) owner = %q, want %q", tc.input, owner, tc.expectedOwner)
+			}
+			if repo != tc.expectedRepo {
+				t.Errorf("resolveOwnerRepo(%q) repo = %q, want %q", tc.input, repo, tc.expectedRepo)
+			}
+			if isGitHub != tc.expectedGitHub {
+				t.Errorf("resolveOwnerRepo(%q) isGitHub = %v, want %v", tc.input, isGitHub, tc.expectedGitHub)
+			}
+		})
+	}
+}
+
+func TestDetectPRNumbers(t *testing.T) {
+	cases := []struct {
+		name     string
+		commits  string
+		expected []int
+	}{
+		{
+			name:     "squash-merge single",
+			commits:  "fix: resolve auth bug (#42)",
+			expected: []int{42},
+		},
+		{
+			name:     "squash-merge multiple",
+			commits:  "feat: add login (#40)\nfix: resolve bug (#42)",
+			expected: []int{40, 42},
+		},
+		{
+			name:     "merge-commit",
+			commits:  "Merge pull request #7 from feature/x",
+			expected: []int{7},
+		},
+		{
+			name:     "merge-commit inline",
+			commits:  "1234abcd Merge pull request #55 from owner/main",
+			expected: []int{55},
+		},
+		{
+			name:     "deduplication",
+			commits:  "feat: a (#3)\nfix: b (#3)",
+			expected: []int{3},
+		},
+		{
+			name:     "no PR refs",
+			commits:  "feat: no pr reference here",
+			expected: []int{},
+		},
+		{
+			name:     "mixed PR and non-PR",
+			commits:  "feat: something (#10)\nbuild: update deps\nMerge pull request #9 from fix/typo",
+			expected: []int{10, 9},
+		},
+		{
+			name:     "big PR number",
+			commits:  "feat: stuff (#999999)",
+			expected: []int{999999},
+		},
+		{
+			name:     "edge case markdown link not PR ref",
+			commits:  "docs: see [PR](#comparison) for details",
+			expected: []int{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectPRNumbers(tc.commits)
+			if len(got) != len(tc.expected) {
+				t.Fatalf("detectPRNumbers(%q) = %v, want %v", tc.commits, got, tc.expected)
+			}
+			for i := range got {
+				if got[i] != tc.expected[i] {
+					t.Errorf("detectPRNumbers(%q)[%d] = %d, want %d", tc.commits, i, got[i], tc.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestMergeEnrichedCommits(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		enriched map[int][]domain.PRCommit
+		want     string
+	}{
+		{
+			name: "single PR replaced",
+			raw:  "feat: add login (#10)",
+			enriched: map[int][]domain.PRCommit{
+				10: {
+					{SHA: "abc", Message: "fix: auth bypass"},
+					{SHA: "def", Message: "test: add auth tests"},
+				},
+			},
+			want: "fix: auth bypass\ntest: add auth tests",
+		},
+		{
+			name: "multi PR mixed with non-PR",
+			raw:  "feat: add login (#10)\nfix: typo\nfeat: dashboard (#20)",
+			enriched: map[int][]domain.PRCommit{
+				10: {
+					{SHA: "a1", Message: "fix: auth"},
+				},
+				20: {
+					{SHA: "b1", Message: "feat: chart"},
+					{SHA: "b2", Message: "feat: grid"},
+				},
+			},
+			want: "fix: auth\nfix: typo\nfeat: chart\nfeat: grid",
+		},
+		{
+			name:     "empty enrichment passthrough",
+			raw:      "feat: no PR here\nfix: bug",
+			enriched: map[int][]domain.PRCommit{},
+			want:     "feat: no PR here\nfix: bug",
+		},
+		{
+			name: "PR not resolved retains original",
+			raw:  "feat: add login (#10)\nfix: typo (#99)",
+			enriched: map[int][]domain.PRCommit{
+				10: {{SHA: "a", Message: "fix: auth"}},
+			},
+			want: "fix: auth\nfix: typo (#99)",
+		},
+		{
+			name: "merge commit format replaced",
+			raw:  "Merge pull request #5 from feat/ui",
+			enriched: map[int][]domain.PRCommit{
+				5: {
+					{SHA: "x", Message: "feat: button"},
+				},
+			},
+			want: "feat: button",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeEnrichedCommits(tc.raw, tc.enriched)
+			if got != tc.want {
+				t.Errorf("mergeEnrichedCommits(%q) =\n%q\nwant:%q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/workflow/prepare_test.go
+++ b/internal/workflow/prepare_test.go
@@ -43,6 +43,7 @@ func (s *stubGitForPrepare) DiffStaged(paths ...string) (string, error)         
 func (s *stubGitForPrepare) ListUntracked() ([]string, error)                   { return nil, nil }
 func (s *stubGitForPrepare) LogFull(limit int) (string, error)                  { return "", nil }
 func (s *stubGitForPrepare) IsRepo() bool                                       { return true }
+func (s *stubGitForPrepare) RemoteURL() (string, error)                         { return "", nil }
 func (s *stubGitForPrepare) LatestTag() (string, error)                         { return "v1.0.0", nil }
 func (s *stubGitForPrepare) CommitsFromTag(sinceTag string) (string, error)     { return "", nil }
 func (s *stubGitForPrepare) TagExists(name string) (bool, error)                { return false, nil }

--- a/internal/workflow/release.go
+++ b/internal/workflow/release.go
@@ -3,7 +3,9 @@
 package workflow
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 
@@ -55,6 +57,7 @@ type ReleaseService struct {
 	git          ports.Git
 	llm          ports.LLM
 	logChunker   LogChunker
+	githubAPI    ports.GitHubAPI // opt-in: nil means no PR enrichment
 	taskLog      *releaseLogger
 	cfg          ReleaseServiceConfig
 	mu           sync.Mutex
@@ -64,11 +67,13 @@ type ReleaseService struct {
 }
 
 // NewReleaseService creates a new ReleaseService.
-func NewReleaseService(git ports.Git, llm ports.LLM, logChunker LogChunker, cfg ReleaseServiceConfig) *ReleaseService {
+// githubAPI is optional — pass nil to disable PR enrichment.
+func NewReleaseService(git ports.Git, llm ports.LLM, logChunker LogChunker, cfg ReleaseServiceConfig, githubAPI ports.GitHubAPI) *ReleaseService {
 	return &ReleaseService{
 		git:          git,
 		llm:          llm,
 		logChunker:   logChunker,
+		githubAPI:    githubAPI,
 		taskLog:      newReleaseLogger(cfg.LogPath, cfg.MaxLogLines),
 		cfg:          cfg,
 		pendingState: "",
@@ -202,6 +207,28 @@ func (s *ReleaseService) Prepare(instruction string, userBump string) (*domain.R
 			if err != nil {
 				s.taskLog.logError(fmt.Sprintf("failed to get commits from tag %s: %v", latestTag, err))
 				commits, _ = s.git.LogFull(100)
+			}
+		}
+	}
+
+	// PR enrichment: if GitHubAPI is available and GITHUB_TOKEN is set,
+	// expand PR references in commit messages into individual PR commits.
+	if s.githubAPI != nil {
+		prNumbers := detectPRNumbers(commits)
+		if len(prNumbers) > 0 {
+			remoteURL, _ := s.git.RemoteURL()
+			owner, repo, isGitHub, _ := resolveOwnerRepo(remoteURL)
+			if isGitHub {
+				ctx := context.Background()
+				enriched, err := s.githubAPI.FetchPRCommits(ctx, owner, repo, prNumbers)
+				if err == nil {
+					enrichedStr := mergeEnrichedCommits(commits, enriched)
+					if enrichedStr != "" {
+						commits = enrichedStr
+					}
+				} else {
+					log.Printf("⚠ PR enrichment failed: %v (using raw commits)", err)
+				}
 			}
 		}
 	}

--- a/internal/workflow/release_service_test.go
+++ b/internal/workflow/release_service_test.go
@@ -17,7 +17,7 @@ func newReleaseSvc(t *testing.T, git *mockGitForRelease, llm *mockLLMForRelease)
 		filepath.Join(dir, "release.log"),
 	)
 	chunker := &mockLogChunker{}
-	return NewReleaseService(git, llm, chunker, cfg)
+	return NewReleaseService(git, llm, chunker, cfg, nil)
 }
 
 func newReleaseSvcWithChunker(t *testing.T, git *mockGitForRelease, llm *mockLLMForRelease, chunker *mockLogChunker) *ReleaseService {
@@ -27,7 +27,7 @@ func newReleaseSvcWithChunker(t *testing.T, git *mockGitForRelease, llm *mockLLM
 		4096, 20, 100,
 		filepath.Join(dir, "release.log"),
 	)
-	return NewReleaseService(git, llm, chunker, cfg)
+	return NewReleaseService(git, llm, chunker, cfg, nil)
 }
 
 // --- DefaultReleaseServiceConfig ---
@@ -249,7 +249,7 @@ func TestReleaseService_Generate_ChunkerError(t *testing.T) {
 	dir := t.TempDir()
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(dir, "release.log"))
 	errChunker := &mockLogChunker{err: fmt.Errorf("log input is empty")}
-	svc := NewReleaseService(git, llm, errChunker, cfg)
+	svc := NewReleaseService(git, llm, errChunker, cfg, nil)
 
 	_, _, err := svc.Generate("anything")
 	if err == nil {

--- a/internal/workflow/release_test.go
+++ b/internal/workflow/release_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -40,6 +41,7 @@ func (m *mockGitForRelease) CurrentBranch() (string, error)   { return "develop"
 func (m *mockGitForRelease) ListBranches(pattern ...string) (string, error) { return m.listBranchesResult, nil }
 func (m *mockGitForRelease) ListTags(pattern ...string) ([]string, error) { return m.listTagsResult, nil }
 func (m *mockGitForRelease) IsRepo() bool                       { return true }
+func (m *mockGitForRelease) RemoteURL() (string, error)           { return "", nil }
 func (m *mockGitForRelease) LatestTag() (string, error) {
 	if m.latestTagResult != "" {
 		return m.latestTagResult, m.latestTagErr
@@ -242,7 +244,7 @@ func TestExecute_PassesChangelogToTag(t *testing.T) {
 	mockChunker := &mockLogChunker{}
 
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
-	svc := NewReleaseService(mockGit, mockLLM, mockChunker, cfg)
+	svc := NewReleaseService(mockGit, mockLLM, mockChunker, cfg, nil)
 
 	intent := &domain.ReleaseIntent{TagName: "v1.2.3"}
 	changelog := "## v1.2.3\n- feat: new stuff"
@@ -270,7 +272,7 @@ func TestExecute_EmptyChangelogPassesEmptyMessage(t *testing.T) {
 	mockChunker := &mockLogChunker{}
 
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
-	svc := NewReleaseService(mockGit, mockLLM, mockChunker, cfg)
+	svc := NewReleaseService(mockGit, mockLLM, mockChunker, cfg, nil)
 
 	intent := &domain.ReleaseIntent{TagName: "v1.0.0"}
 	_, err := svc.Execute(intent, "")
@@ -338,7 +340,7 @@ func TestDetectBranchFlow(t *testing.T) {
 			mockChunker := &mockLogChunker{}
 
 			cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release_test.log"))
-			svc := NewReleaseService(mockGit, mockLLM, mockChunker, cfg)
+			svc := NewReleaseService(mockGit, mockLLM, mockChunker, cfg, nil)
 
 			got, err := svc.DetectBranchFlow()
 			if (err != nil) != tt.wantErr {
@@ -386,7 +388,7 @@ func TestBuildPreview(t *testing.T) {
 			mockChunker := &mockLogChunker{}
 
 			cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release_test.log"))
-			svc := NewReleaseService(mockGit, mockLLM, mockChunker, cfg)
+			svc := NewReleaseService(mockGit, mockLLM, mockChunker, cfg, nil)
 
 			got := svc.BuildPreview(tt.intent, tt.changelog)
 
@@ -440,4 +442,162 @@ func findSubstring(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// mockGitHubAPI implements ports.GitHubAPI for testing.
+type mockGitHubAPI struct {
+	fetchResult map[int][]domain.PRCommit
+	fetchErr    error
+	called      bool
+	calledPRs   []int
+}
+
+func (m *mockGitHubAPI) FetchPRCommits(ctx context.Context, owner, repo string, prNumbers []int) (map[int][]domain.PRCommit, error) {
+	m.called = true
+	m.calledPRs = prNumbers
+	if m.fetchErr != nil {
+		return nil, m.fetchErr
+	}
+	return m.fetchResult, nil
+}
+
+// mockGitForReleaseWithRemoteURL returns a specific remote URL.
+type mockGitForReleaseWithRemoteURL struct {
+	mockGitForRelease
+	remoteURL    string
+	remoteURLErr error
+}
+
+func (m *mockGitForReleaseWithRemoteURL) RemoteURL() (string, error) {
+	return m.remoteURL, m.remoteURLErr
+}
+
+// TestPrepare_WithPREnrichment verifies that Prepare calls enrichment
+// when githubAPI is provided and commits contain PR references.
+func TestPrepare_WithPREnrichment(t *testing.T) {
+	git := &mockGitForReleaseWithRemoteURL{
+		mockGitForRelease: mockGitForRelease{
+			latestTagResult: "v1.0.0",
+			commitsResult:   "Merge pull request #42 from feature/foo\nfix: use new API (#40)",
+			listTagsResult:  []string{"v1.0.0"},
+		},
+		remoteURL: "git@github.com:Alejandro-M-P/git-courer.git",
+	}
+	llm := &mockLLMForRelease{}
+	chunker := &mockLogChunker{}
+	ghAPI := &mockGitHubAPI{
+		fetchResult: map[int][]domain.PRCommit{
+			42: {
+				{SHA: "abc123", Message: "feat: add new feature from PR 42", Author: "dev1"},
+			},
+		},
+	}
+
+	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
+	svc := NewReleaseService(git, llm, chunker, cfg, ghAPI)
+
+	_, commits, _, err := svc.Prepare("sacar versión minor", "")
+	if err != nil {
+		t.Fatalf("Prepare() error: %v", err)
+	}
+
+	if !ghAPI.called {
+		t.Fatal("expected githubAPI.FetchPRCommits to be called")
+	}
+	if len(ghAPI.calledPRs) == 0 {
+		t.Fatal("expected PR numbers to be passed to FetchPRCommits")
+	}
+	// Enhanced commits should contain the PR detail, not the merge commit line
+	if commits == "" {
+		t.Fatal("expected non-empty commits")
+	}
+	t.Logf("Enriched commits:\n%s", commits)
+}
+
+// TestPrepare_WithPREnrichment_ErrorFallback verifies that enrichment
+// errors fall back to raw commits silently.
+func TestPrepare_WithPREnrichment_ErrorFallback(t *testing.T) {
+	git := &mockGitForReleaseWithRemoteURL{
+		mockGitForRelease: mockGitForRelease{
+			latestTagResult: "v1.0.0",
+			commitsResult:   "Merge pull request #42 from feature/foo\nfix: some bug",
+			listTagsResult:  []string{"v1.0.0"},
+		},
+		remoteURL: "git@github.com:Alejandro-M-P/git-courer.git",
+	}
+	llm := &mockLLMForRelease{}
+	chunker := &mockLogChunker{}
+	ghAPI := &mockGitHubAPI{
+		fetchErr: fmt.Errorf("API rate limit exceeded"),
+	}
+
+	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
+	svc := NewReleaseService(git, llm, chunker, cfg, ghAPI)
+
+	_, commits, _, err := svc.Prepare("sacar versión minor", "")
+	if err != nil {
+		t.Fatalf("Prepare() error: %v", err)
+	}
+
+	// Should fall back to raw commits
+	if !ghAPI.called {
+		t.Fatal("expected githubAPI.FetchPRCommits to be called even on error")
+	}
+	if commits == "" {
+		t.Fatal("expected fallback to raw commits")
+	}
+	t.Logf("Fallback commits:\n%s", commits)
+}
+
+// TestPrepare_WithPREnrichment_NonGitHubSkipsEnrichment verifies that
+// non-GitHub remotes skip enrichment entirely.
+func TestPrepare_WithPREnrichment_NonGitHubSkipsEnrichment(t *testing.T) {
+	git := &mockGitForReleaseWithRemoteURL{
+		mockGitForRelease: mockGitForRelease{
+			latestTagResult: "v1.0.0",
+			commitsResult:   "Merge pull request #42 from feature/foo\nfix: some bug",
+			listTagsResult:  []string{"v1.0.0"},
+		},
+		remoteURL: "git@gitlab.com:user/repo.git",
+	}
+	llm := &mockLLMForRelease{}
+	chunker := &mockLogChunker{}
+	ghAPI := &mockGitHubAPI{}
+
+	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
+	svc := NewReleaseService(git, llm, chunker, cfg, ghAPI)
+
+	_, _, _, err := svc.Prepare("sacar versión minor", "")
+	if err != nil {
+		t.Fatalf("Prepare() error: %v", err)
+	}
+
+	if ghAPI.called {
+		t.Error("expected githubAPI NOT to be called for non-GitHub remote")
+	}
+}
+
+// TestPrepare_WithNilGitHubAPI_NoEnrichment verifies that nil githubAPI
+// does not attempt enrichment (opt-in only).
+func TestPrepare_WithNilGitHubAPI_NoEnrichment(t *testing.T) {
+	git := &mockGitForRelease{
+		latestTagResult: "v1.0.0",
+		commitsResult:   "Merge pull request #42 from feature/foo\nfix: some bug",
+		listTagsResult:  []string{"v1.0.0"},
+	}
+	llm := &mockLLMForRelease{}
+	chunker := &mockLogChunker{}
+
+	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
+	svc := NewReleaseService(git, llm, chunker, cfg, nil)
+
+	_, commits, _, err := svc.Prepare("sacar versión minor", "")
+	if err != nil {
+		t.Fatalf("Prepare() error: %v", err)
+	}
+
+	// Should work fine with nil githubAPI — no enrichment
+	if commits == "" {
+		t.Fatal("expected commits from nil githubAPI path")
+	}
 }

--- a/test/e2e/shared_test.go
+++ b/test/e2e/shared_test.go
@@ -102,7 +102,7 @@ func makeWorkflow(t *testing.T, gitA ports.Git, llmA ports.LLM) (*workflow.Workf
 	commitCfg := workflow.DefaultCommitServiceConfig(4096, 50, filepath.Join(t.TempDir(), "commit.log"))
 	commit := workflow.NewCommitService(gitA, llmA, chunkers.NewDiffChunker(), sec, commitCfg)
 	releaseCfg := workflow.DefaultReleaseServiceConfig(4096, 20, 50, filepath.Join(t.TempDir(), "release.log"))
-	release := workflow.NewReleaseService(gitA, llmA, chunkers.NewLogChunker(4096), releaseCfg)
+	release := workflow.NewReleaseService(gitA, llmA, chunkers.NewLogChunker(4096), releaseCfg, nil)
 	return workflow.New(gitA, llmA, c, cfg, commit, release, sec), c
 }
 

--- a/test/e2e/workflow_test.go
+++ b/test/e2e/workflow_test.go
@@ -41,6 +41,7 @@ func (m *mockGit) ListBranches(pattern ...string) (string, error) {
 }
 func (m *mockGit) ListTags(pattern ...string) ([]string, error) { return m.listTagsResult, nil }
 func (m *mockGit) IsRepo() bool                                 { return true }
+func (m *mockGit) RemoteURL() (string, error)                    { return "", nil }
 func (m *mockGit) LatestTag() (string, error)                   { return m.latestTagResult, nil }
 func (m *mockGit) CommitsFromTag(sinceTag string) (string, error) {
 	return m.commitsResult, nil
@@ -180,7 +181,7 @@ func TestExistingTagReturnsError(t *testing.T) {
 	chunker := &mockLogChunker{}
 
 	cfg := workflow.DefaultReleaseServiceConfig(4096, 20, 50, tempLogPath(t))
-	svc := workflow.NewReleaseService(git, llm, chunker, cfg)
+	svc := workflow.NewReleaseService(git, llm, chunker, cfg, nil)
 
 	intent := &domain.ReleaseIntent{TagName: "v1.0.0", IsRelease: true}
 	_, err := svc.Execute(intent, "## Changelog")
@@ -203,7 +204,7 @@ func TestReleaseStateErrorIsPropagated(t *testing.T) {
 	git := &mockGit{}
 	llm := &mockLLM{}
 	chunker := &mockLogChunker{}
-	svc := workflow.NewReleaseService(git, llm, chunker, cfg)
+	svc := workflow.NewReleaseService(git, llm, chunker, cfg, nil)
 
 	// Simulate goroutine writing an error state
 	svc.SaveState("error: connection refused")
@@ -236,7 +237,7 @@ func TestReleaseFullFlow(t *testing.T) {
 	chunker := &mockLogChunker{}
 
 	cfg := workflow.DefaultReleaseServiceConfigWithPaths(4096, 20, 50, tempLogPath(t))
-	svc := workflow.NewReleaseService(git, llm, chunker, cfg)
+	svc := workflow.NewReleaseService(git, llm, chunker, cfg, nil)
 
 	intent, commits, _, err := svc.Prepare("release version 1.1.0", "")
 	if err != nil {
@@ -313,7 +314,7 @@ func TestPreviousTagSemverOrdering(t *testing.T) {
 	chunker := &mockLogChunker{}
 
 	cfg := workflow.DefaultReleaseServiceConfigWithPaths(4096, 20, 50, tempLogPath(t))
-	svc := workflow.NewReleaseService(git, llm, chunker, cfg)
+	svc := workflow.NewReleaseService(git, llm, chunker, cfg, nil)
 
 	intent, _, _, err := svc.Prepare("bump minor", "")
 	if err != nil {


### PR DESCRIPTION
## Summary

When GitHub PRs are squash-merged or merge-committed into `main`, the commit message loses all original PR detail. For example, a PR with 14 commits becomes one fat commit `fix: use CreateGitHubRelease from ReleaseService config (#40)`. This change fetches the original PR commits from GitHub API and injects them into the changelog input.

## What changed

### New files
- `internal/core/domain/pr.go` — `PRCommit{SHA, Message, Author}`
- `internal/core/ports/github.go` — `GitHubAPI` port with `FetchPRCommits`
- `internal/adapters/github/client.go` — go-github/v74 adapter with `errgroup` parallel fetch (cap 5)
- `internal/adapters/github/client_test.go` — httptest-based unit tests
- `internal/adapters/github/client_integration_test.go` — live API test against PR #40
- `internal/workflow/pr_enrich.go` — pure functions: `detectPRNumbers`, `mergeEnrichedCommits`, `resolveOwnerRepo`
- `internal/workflow/pr_enrich_test.go` — table-driven tests for all 5 URL formats, PR detection, merge logic

### Modified files
- `internal/core/ports/git.go` — added `RemoteURL() (string, error)`
- `internal/adapters/git/exec.go` — implemented `RemoteURL()` via `git remote get-url origin`
- `internal/workflow/release.go` — enrichment step in `Prepare()` after `CommitsFromTag()`
- `internal/delivery/mcp/server.go` — injects `GitHubAPI` adapter when `GITHUB_TOKEN` is set
- `go.mod` — added `github.com/whilp/git-urls`, promoted `go-github/v74` to direct, added `golang.org/x/sync/errgroup`
- `internal/adapters/llm/openai_standard/adapter.go` — added missing `IsWarmed()` method (bugfix)

## Capabilities added

| Capability | Description |
|------------|-------------|
| `pr-commit-detection` | Regex detects squash-merge `(#N)` and merge-commit `Merge pull request #N` patterns |
| `remote-url-parsing` | `git-urls` library parses all 5 git remote URL formats including SSH with explicit port |
| `github-api-enrichment` | go-github v74 adapter fetches PR commits in parallel with errgroup cap 5 |
| `github-api-adapter` | New port `GitHubAPI` with `FetchPRCommits` — opt-in, nil-safe |

## Design decisions

- **Only GitHub** — non-github.com remotes skip enrichment silently
- **Fallback mandatory** — if no token, API fails, or 404 → fat commit is used, never blocks
- **Parallel** — errgroup with cap 5, not WaitGroup
- **Token** — `GITHUB_TOKEN` env var, injected at server startup in `server.go`
- **No caching** — each release makes fresh API calls

## Testing

- **74+ unit tests** pass across workflow, github adapter, core packages
- **Live integration test** verified against real PR #40 (14 commits fetched successfully)
- Test files: `pr_enrich_test.go`, `client_test.go`, `release_test.go`

## Breaking changes

None. Feature is opt-in — `ReleaseService` enriches only when `githubAPI != nil` (set when `GITHUB_TOKEN` env var is present).

## Files

```
internal/adapters/github/client.go            | new
internal/adapters/github/client_test.go       | new
internal/adapters/github/client_integration_test.go | new
internal/core/domain/pr.go                   | new
internal/core/ports/github.go                | new
internal/workflow/pr_enrich.go                | new
internal/workflow/pr_enrich_test.go           | new
internal/core/ports/git.go                    | modified
internal/adapters/git/exec.go                | modified
internal/workflow/release.go                  | modified
internal/delivery/mcp/server.go              | modified
go.mod                                        | modified
internal/adapters/llm/openai_standard/adapter.go | modified (bugfix)
internal/workflow/release_test.go             | modified
internal/integration/ollama_flow_test.go      | modified
internal/integration/workflow_matrix_test.go  | modified
internal/workflow/commit_service_test.go      | modified
internal/workflow/prepare_test.go            | modified
test/e2e/shared_test.go                       | modified
test/e2e/workflow_test.go                     | modified
```