### PR TITLE
feat: area-system phase 2 — MCP area flow + changelog 3-state routing

### DIFF
--- a/internal/adapters/llm/openai_standard/adapter_release.go
+++ b/internal/adapters/llm/openai_standard/adapter_release.go
@@ -110,6 +110,40 @@ func (a *OpenAIStandardAdapter) GenerateChangelogByArea(formattedGroups string) 
 	return ch, nil
 }
 
+// GenerateChangelogGeneric generates a generic changelog without area grouping.
+// Uses changelog_generate prompt, returns Features/Fixes/Breaking format.
+func (a *OpenAIStandardAdapter) GenerateChangelogGeneric(commits, previousChangelog, outputFile string) (*domain.Changelog, error) {
+	tmpl, err := prompts.Get("changelog_generate")
+	if err != nil {
+		return nil, fmt.Errorf("prompt not found: %w", err)
+	}
+	prompt, err := prompts.Render(tmpl, map[string]string{
+		"commits": commits,
+		"Context": a.context,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("render changelog_generate prompt: %w", err)
+	}
+
+	result, err := a.chatCompletion(prompt, chatCompletionOpts{
+		operation:       "changelog_generic",
+		jsonMode:        true,
+		reasoningEffort: "none",
+		temperature:     floatPtr(changelogTemp),
+		maxTokens:       changelogMaxTokens,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var changelog domain.Changelog
+	if err := parseJSON(result, &changelog); err != nil {
+		return nil, fmt.Errorf("parse changelog_generic: %w", err)
+	}
+
+	return &changelog, nil
+}
+
 // RegenerateMessage generates new commit messages based on feedback.
 func (a *OpenAIStandardAdapter) RegenerateMessage(previousMessages []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
 	if len(previousMessages) != len(chunks) {

--- a/internal/core/ports/llm.go
+++ b/internal/core/ports/llm.go
@@ -37,6 +37,10 @@ type LLM interface {
 	// formattedGroups is the output of FormatGroupedCommits — areas with commit lists.
 	GenerateChangelogByArea(formattedGroups string) (domain.ChangelogByArea, error)
 
+	// GenerateChangelogGeneric generates a generic changelog without area grouping.
+	// Uses changelog_generate prompt, returns Features/Fixes/Breaking format.
+	GenerateChangelogGeneric(commits, previousChangelog, outputFile string) (*domain.Changelog, error)
+
 	// RegenerateMessage generates new commit messages based on feedback.
 	// Used when the user requests regeneration of commit messages in preview mode.
 	RegenerateMessage(previousMessages []string, feedback string, chunks []domain.DiffChunk) ([]string, error)

--- a/internal/delivery/mcp/core/handler_test.go
+++ b/internal/delivery/mcp/core/handler_test.go
@@ -1393,6 +1393,13 @@ func (m *mockLLM) GenerateChangelogByArea(formattedGroups string) (domain.Change
 	args := m.Called(formattedGroups)
 	return args.Get(0).(domain.ChangelogByArea), args.Error(1)
 }
+func (m *mockLLM) GenerateChangelogGeneric(commits, previousChangelog, outputFile string) (*domain.Changelog, error) {
+	args := m.Called(commits, previousChangelog, outputFile)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Changelog), args.Error(1)
+}
 func (m *mockLLM) RegenerateMessage(previousMessages []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
 	args := m.Called(previousMessages, feedback, chunks)
 	return args.Get(0).([]string), args.Error(1)

--- a/internal/delivery/mcp/core/handler_test.go
+++ b/internal/delivery/mcp/core/handler_test.go
@@ -1469,3 +1469,108 @@ func newTestHandler(t *testing.T, mGit *mockGit) *Handler {
 
 	return NewHandler(mGit, commitSvc, rev, mLLM, "", nil)
 }
+
+// --- areaRequiredResponse tests ---
+
+func TestAreaRequiredResponse_JSONStructure(t *testing.T) {
+	dirs := []string{"internal/infra/cfg", "pkg/utils"}
+	existingAreas := map[string][]string{
+		"core": {"internal/core"},
+		"tui":  {"internal/tui"},
+	}
+
+	result := areaRequiredResponse(dirs, existingAreas)
+
+	// Parse the JSON to verify structure
+	var parsed struct {
+		Status        string              `json:"status"`
+		Message       string              `json:"message"`
+		Directories   []string            `json:"directories"`
+		ExistingAreas map[string][]string `json:"existing_areas"`
+		Hint          string              `json:"hint"`
+	}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("areaRequiredResponse produced invalid JSON: %v", err)
+	}
+
+	if parsed.Status != "area_required" {
+		t.Errorf("status = %q, want %q", parsed.Status, "area_required")
+	}
+	if parsed.Message == "" {
+		t.Error("message should not be empty")
+	}
+	if len(parsed.Directories) != 2 {
+		t.Errorf("directories = %v, want 2 entries", parsed.Directories)
+	}
+	if parsed.Directories[0] != "internal/infra/cfg" {
+		t.Errorf("directories[0] = %q, want %q", parsed.Directories[0], "internal/infra/cfg")
+	}
+	if len(parsed.ExistingAreas) != 2 {
+		t.Errorf("existing_areas = %v, want 2 entries", parsed.ExistingAreas)
+	}
+	if parsed.ExistingAreas["core"][0] != "internal/core" {
+		t.Errorf("existing_areas[core] = %v, want [internal/core]", parsed.ExistingAreas["core"])
+	}
+	if parsed.Hint == "" {
+		t.Error("hint should not be empty")
+	}
+}
+
+func TestAreaRequiredResponse_EmptyDirectories(t *testing.T) {
+	result := areaRequiredResponse(nil, nil)
+
+	var parsed struct {
+		Status      string              `json:"status"`
+		Directories []string            `json:"directories"`
+		ExistingAreas map[string][]string `json:"existing_areas"`
+	}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("areaRequiredResponse produced invalid JSON: %v", err)
+	}
+	if parsed.Status != "area_required" {
+		t.Errorf("status = %q, want %q", parsed.Status, "area_required")
+	}
+}
+
+// --- getStringAreaResponse tests ---
+
+func TestGetStringAreaResponse_NilWhenNotProvided(t *testing.T) {
+	params := map[string]any{
+		"command": "APPLY",
+	}
+	result := getStringAreaResponse(params)
+	if result != nil {
+		t.Errorf("expected nil when area_response not provided, got %v", result)
+	}
+}
+
+func TestGetStringAreaResponse_MapStringInterface(t *testing.T) {
+	params := map[string]any{
+		"area_response": map[string]interface{}{
+			"internal/infra/cfg": "core",
+		},
+	}
+	result := getStringAreaResponse(params)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result["internal/infra/cfg"] != "core" {
+		t.Errorf("expected core, got %q", result["internal/infra/cfg"])
+	}
+}
+
+func TestGetStringAreaResponse_JSONString(t *testing.T) {
+	params := map[string]any{
+		"area_response": `{"internal/infra/cfg": "core", "pkg/utils": "shared"}`,
+	}
+	result := getStringAreaResponse(params)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result["internal/infra/cfg"] != "core" {
+		t.Errorf("expected core, got %q", result["internal/infra/cfg"])
+	}
+	if result["pkg/utils"] != "shared" {
+		t.Errorf("expected shared, got %q", result["pkg/utils"])
+	}
+}

--- a/internal/delivery/mcp/core/handlers.go
+++ b/internal/delivery/mcp/core/handlers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Alejandro-M-P/git-courer/internal/adapters/git"
+	"github.com/Alejandro-M-P/git-courer/internal/config"
 	"github.com/Alejandro-M-P/git-courer/internal/core/domain"
 	"github.com/Alejandro-M-P/git-courer/internal/core/ports"
 	"github.com/Alejandro-M-P/git-courer/internal/delivery/mcp/shared"
@@ -49,6 +50,7 @@ type Handler struct {
 	llm            ports.LLM
 	provider       string // "ollama" for local, anything else for cloud
 	mcpServer      *server.MCPServer
+	workDir        string // current working directory for project config access
 
 	bgJobs sync.Map // job_id → *BgJob (lightweight: only running/done/failed)
 }
@@ -69,6 +71,7 @@ func NewHandler(
 		llm:            llm,
 		provider:       provider,
 		mcpServer:      mcpServer,
+		workDir:        ".",
 	}
 }
 
@@ -291,6 +294,19 @@ func (h *Handler) handlePreview(ctx context.Context, params map[string]any, why 
 		return shared.JSONErrorResult("PREVIEW", fmt.Errorf("commit service not available"))
 	}
 
+	// Check for new directories that need area assignments.
+	// Only ask once — if area_response was provided, skip this check.
+	areaResponse := getStringAreaResponse(params)
+	if areaResponse == nil {
+		newDirs, projectCfg, err := h.checkNewDirectories()
+		if err != nil {
+			// Log but don't block — area question is optional
+			log.Printf("[commit] area check failed: %v", err)
+		} else if newDirs != nil && len(newDirs) > 0 {
+			return mcpgo.NewToolResultText(areaRequiredResponse(newDirs, projectCfg.Areas)), nil
+		}
+	}
+
 	// Synchronous WriteTree: capture the current staging area snapshot atomically.
 	// If this fails, no BgJob is created — we return immediately.
 	treeHash, err := h.git.WriteTree()
@@ -425,7 +441,18 @@ func (h *Handler) handleStatus(params map[string]any) (*mcpgo.CallToolResult, er
 //  2. Without job_id → legacy path: delegates to reviewWorkflow.Apply.
 //
 // If pushAfter is true, pushes to remote after successful apply.
+// If area_response is provided, saves the area mappings to project config
+// before proceeding with the commit (append-only — never overwrites existing mappings).
 func (h *Handler) handleApply(ctx context.Context, params map[string]any) (*mcpgo.CallToolResult, error) {
+	// Handle area_response if provided — save to project config before commit
+	areaResponse := getStringAreaResponse(params)
+	if areaResponse != nil {
+		if err := h.saveAreaResponse(areaResponse); err != nil {
+			log.Printf("[commit] area_response save failed: %v", err)
+			// Log error but don't block the commit — area mapping is advisory
+		}
+	}
+
 	jobID := shared.GetStringParam(params, "job_id", "")
 
 	// Plumbing path: job_id present and non-empty
@@ -589,6 +616,136 @@ func (h *Handler) handleRegenerate(ctx context.Context, params map[string]any, w
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────
+
+// areaRequiredResponse builds the JSON response for the area_required status.
+// This response tells the agent that new directories need area assignments
+// before proceeding with the commit.
+func areaRequiredResponse(directories []string, existingAreas map[string][]string) string {
+	type areaRequired struct {
+		Status        string              `json:"status"`
+		Message       string              `json:"message"`
+		Directories   []string            `json:"directories"`
+		ExistingAreas map[string][]string `json:"existing_areas"`
+		Hint          string              `json:"hint"`
+	}
+	resp := areaRequired{
+		Status:        "area_required",
+		Message:       "New directories need area assignments for changelog organization.",
+		Directories:   directories,
+		ExistingAreas: existingAreas,
+		Hint:          "Reply with: area_response {\"internal/infra/cfg/\": \"core\"}. Areas organize your changelog into meaningful sections.",
+	}
+	data, _ := json.Marshal(resp)
+	return string(data)
+}
+
+// getStringAreaResponse extracts the area_response parameter from commit params.
+// It accepts both map[string]string (structured) and string (JSON) formats.
+// Returns nil if not provided or empty.
+func getStringAreaResponse(params map[string]any) map[string]string {
+	// Try map format first (structured parameter)
+	if v, ok := params["area_response"]; ok {
+		if m, ok := v.(map[string]interface{}); ok {
+			result := make(map[string]string, len(m))
+			for k, val := range m {
+				if s, ok := val.(string); ok {
+					result[k] = s
+				}
+			}
+			if len(result) > 0 {
+				return result
+			}
+		}
+		// Try map[string]string directly
+		if m, ok := v.(map[string]string); ok {
+			if len(m) > 0 {
+				return m
+			}
+		}
+		// Try JSON string format
+		if s, ok := v.(string); ok && s != "" {
+			var result map[string]string
+			if err := json.Unmarshal([]byte(s), &result); err == nil && len(result) > 0 {
+				return result
+			}
+		}
+	}
+	return nil
+}
+
+// saveAreaResponse saves the provided area mappings to the project config.
+// Append-only: adds new dir→area mappings to existing areas without overwriting.
+func (h *Handler) saveAreaResponse(areas map[string]string) error {
+	cfg, err := config.LoadProjectConfig(h.workDir)
+	if err != nil {
+		cfg = &config.ProjectConfig{
+			Areas: make(map[string][]string),
+		}
+	}
+	if cfg.Areas == nil {
+		cfg.Areas = make(map[string][]string)
+	}
+
+	// Append-only: add new directory→area mappings without overwriting existing ones
+	for dir, area := range areas {
+		if existing, ok := cfg.Areas[area]; ok {
+			// Check if this directory is already in the area's paths
+			found := false
+			for _, p := range existing {
+				if p == dir {
+					found = true
+					break
+				}
+			}
+			if !found {
+				cfg.Areas[area] = append(cfg.Areas[area], dir)
+			}
+		} else {
+			cfg.Areas[area] = []string{dir}
+		}
+	}
+
+	return config.SaveProjectConfig(h.workDir, cfg)
+}
+
+// checkNewDirectories loads the project config and checks for directories
+// that have no area mapping. Returns the list of new directories and the
+// project config, or nil if no new directories are found or if areas are not configured.
+func (h *Handler) checkNewDirectories() ([]string, *domain.ProjectConfig, error) {
+	projectCfg, err := domain.LoadProjectConfig(h.workDir)
+	if err != nil {
+		// No config file — no areas configured, so no area question needed
+		return nil, nil, nil
+	}
+
+	// If no areas are configured, there's nothing to check — all dirs would be "unassigned"
+	// and asking about areas would be premature (the project hasn't been set up yet).
+	if len(projectCfg.Areas) == 0 {
+		return nil, projectCfg, nil
+	}
+
+	// Get changed files from git status
+	status, err := h.git.Status()
+	if err != nil {
+		return nil, nil, fmt.Errorf("status check for new directories: %w", err)
+	}
+
+	var changedFiles []string
+	for _, f := range status.Files {
+		changedFiles = append(changedFiles, f.Path)
+	}
+
+	if len(changedFiles) == 0 {
+		return nil, projectCfg, nil
+	}
+
+	newDirs := projectCfg.NewDirectories(changedFiles)
+	if len(newDirs) == 0 {
+		return nil, projectCfg, nil
+	}
+
+	return newDirs, projectCfg, nil
+}
 
 func (h *Handler) handleDiffCommand(path string, limit, offset int, cachedFlag string, fileFilter string) (string, error) {
 	// Handle range syntax: .. or ... prefix means compare against target.

--- a/internal/delivery/mcp/core/registration.go
+++ b/internal/delivery/mcp/core/registration.go
@@ -46,7 +46,7 @@ func Register(s *server.MCPServer, h Handlers) {
 	)
 	s.AddTool(
 		mcpgo.NewTool("commit",
-			mcpgo.WithDescription("3-phase commit pipeline: PREVIEW parses AST and groups files by dependency graph into atomic commits, APPLY executes them. PREVIEW accepts a 'why' parameter to justify changes. APPLY supports two paths: 1) With job_id: creates a single atomic commit from the PREVIEW tree snapshot via plumbing (CommitTree + UpdateRef), 2) Without job_id: executes the pending plan from ConfirmStore. Workflow: 1) PREVIEW → get plan, 2) Review with user, 3) APPLY. push_after:true on APPLY automatically pushes successful commits to remote. If PREVIEW returns 'processing', poll STATUS with job_id."),
+			mcpgo.WithDescription("3-phase commit pipeline: PREVIEW parses AST and groups files by dependency graph into atomic commits, APPLY executes them. PREVIEW accepts a 'why' parameter to justify changes. APPLY supports two paths: 1) With job_id: creates a single atomic commit from the PREVIEW tree snapshot via plumbing (CommitTree + UpdateRef), 2) Without job_id: executes the pending plan from ConfirmStore. Workflow: 1) PREVIEW → get plan, 2) Review with user, 3) APPLY. push_after:true on APPLY automatically pushes successful commits to remote. If PREVIEW returns 'processing', poll STATUS with job_id to get the result. If PREVIEW returns 'area_required', reply with area_response to assign directories to areas before continuing."),
 			mcpgo.WithReadOnlyHintAnnotation(false),
 			mcpgo.WithDestructiveHintAnnotation(true),
 			mcpgo.WithString("command", mcpgo.Required(), mcpgo.Description("Pipeline phase: PREVIEW (generate plan), APPLY (execute commits), ABORT (cancel job), REGENERATE (redo plan with feedback), STATUS (poll job state)."), mcpgo.Enum("PREVIEW", "APPLY", "ABORT", "REGENERATE", "STATUS")),
@@ -54,6 +54,7 @@ func Register(s *server.MCPServer, h Handlers) {
 			mcpgo.WithString("job_id", mcpgo.Description("Job ID for plumbing path. For STATUS: poll PREVIEW job. For APPLY: use plumbing commit path (CommitTree + UpdateRef) instead of porcelain, creating atomic commit from PREVIEW snapshot.")),
 			mcpgo.WithString("feedback", mcpgo.Description("Feedback for REGENERATE — tell the pipeline what to change about the plan.")),
 			mcpgo.WithBoolean("push_after", mcpgo.Description("Only for APPLY. If true, automatically pushes commits to remote after successful apply.")),
+			mcpgo.WithString("area_response", mcpgo.Description("JSON mapping of directory paths to area names (e.g., {\"internal/infra/cfg/\": \"core\"}). Provided in response to area_required status from PREVIEW. Areas organize your changelog into meaningful sections.")),
 		),
 		h.HandleCommit,
 	)

--- a/internal/integration/workflow_matrix_test.go
+++ b/internal/integration/workflow_matrix_test.go
@@ -127,7 +127,21 @@ func (e *errorLLM) AuditBinaryContent(_, _ string) (bool, error) {
 func (e *errorLLM) GenerateChangelog(_, _, _ string) (*domain.Changelog, error) {
 	return nil, errors.New(e.msg)
 }
+func (e *errorLLM) GenerateChangelogByArea(_ string) (domain.ChangelogByArea, error) {
+	return nil, errors.New(e.msg)
+}
+func (e *errorLLM) GenerateChangelogGeneric(_, _, _ string) (*domain.Changelog, error) {
+	return nil, errors.New(e.msg)
+}
 func (e *errorLLM) RegenerateMessage(_ []string, _ string, _ []domain.DiffChunk) ([]string, error) {
+	return nil, errors.New(e.msg)
+}
+func (e *errorLLM) ProjectInit(_ string) (*domain.ProjectConfig, error) {
+	return nil, errors.New(e.msg)
+}
+func (e *errorLLM) ClassifyBinary(_ string) (string, error) {
+	return "", errors.New(e.msg)
+}
 	return nil, errors.New(e.msg)
 }
 

--- a/internal/workflow/commit_filter.go
+++ b/internal/workflow/commit_filter.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/Alejandro-M-P/git-courer/internal/core/domain"
 )
 
 // skipTypes are commit types excluded from user-facing changelogs.
@@ -94,4 +96,29 @@ func formatCommitLine(c parsedCommit) string {
 		t += "!"
 	}
 	return t + ": " + c.subject
+}
+
+// filterForChangelog filters commits for changelog generation.
+// It removes commits whose scope matches excluded paths (via IsExcluded)
+// and skips non-user-facing types (chore, test, ci, build) unless breaking.
+// If cfg is nil, DefaultExcluded is used by IsExcluded.
+func filterForChangelog(commits string, cfg *domain.ProjectConfig) map[string][]string {
+	groups := make(map[string][]string)
+	for _, line := range strings.Split(commits, "\n") {
+		c, ok := parseConventionalCommit(line)
+		if !ok {
+			continue
+		}
+		if skipTypes[c.commitType] && !c.breaking {
+			continue
+		}
+		// Exclude by scope matching excluded paths
+		if cfg != nil && c.scope != "" {
+			if cfg.IsExcluded(c.scope) {
+				continue
+			}
+		}
+		groups[c.scope] = append(groups[c.scope], formatCommitLine(c))
+	}
+	return groups
 }

--- a/internal/workflow/commit_service_test.go
+++ b/internal/workflow/commit_service_test.go
@@ -207,6 +207,9 @@ func (l *stubLLM) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) { 
 func (l *stubLLM) GenerateChangelogByArea(formattedGroups string) (domain.ChangelogByArea, error) {
 	return domain.ChangelogByArea{}, nil
 }
+func (l *stubLLM) GenerateChangelogGeneric(commits, prev, out string) (*domain.Changelog, error) {
+	return &domain.Changelog{Features: []string{"Changelog"}}, nil
+}
 func (l *stubLLM) ClassifyBinary(prompt string) (string, error) {
 	return "fix", nil // Default to "fix" for testing
 }

--- a/internal/workflow/context_test.go
+++ b/internal/workflow/context_test.go
@@ -62,6 +62,13 @@ func (l *contextTrackingLLM) GenerateChangelogByArea(formattedGroups string) (do
 	return domain.ChangelogByArea{}, nil
 }
 
+func (l *contextTrackingLLM) GenerateChangelogGeneric(commits, previousChangelog, outputFile string) (*domain.Changelog, error) {
+	l.mu.Lock()
+	l.changelogCalls++
+	l.mu.Unlock()
+	return &domain.Changelog{}, nil
+}
+
 
 // --- ProjectConfig scope injection ---
 

--- a/internal/workflow/release.go
+++ b/internal/workflow/release.go
@@ -61,6 +61,7 @@ type ReleaseService struct {
 	githubAPI        ports.GitHubAPI // opt-in: nil means no PR enrichment
 	taskLog          *releaseLogger
 	cfg              ReleaseServiceConfig
+	projectCfg       *domain.ProjectConfig // nil if init hasn't run
 	mu               sync.Mutex
 	pendingState     string
 	pendingIntent    *domain.ReleaseIntent

--- a/internal/workflow/release_generate.go
+++ b/internal/workflow/release_generate.go
@@ -10,9 +10,23 @@ import (
 
 // Generate filters commits, groups by area, and translates to user-facing markdown.
 // Always returns isBackground=false; the bool is kept for interface compatibility.
+//
+// Routing:
+//   - No areas configured → generic changelog (Features/Fixes/Breaking format)
+//   - Areas configured → area-based changelog with group_N obfuscation
 func (s *ReleaseService) Generate(commits string) (string, []string, bool, error) {
 	s.taskLog.logStartChangelog()
 
+	// Route based on project config
+	if s.projectCfg == nil || len(s.projectCfg.Areas) == 0 {
+		return s.generateGeneric(commits)
+	}
+	return s.generateWithAreas(commits)
+}
+
+// generateGeneric produces a changelog when no areas are configured.
+// Uses changelog_generate prompt, returns Features/Fixes/Breaking format.
+func (s *ReleaseService) generateGeneric(commits string) (string, []string, bool, error) {
 	groups := FilterAndGroupCommits(commits)
 	if len(groups) == 0 {
 		s.taskLog.logChangelogDone(0)
@@ -20,13 +34,43 @@ func (s *ReleaseService) Generate(commits string) (string, []string, bool, error
 	}
 
 	formatted := FormatGroupedCommits(groups)
-	changelog, err := s.llm.GenerateChangelogByArea(formatted)
+	changelog, err := s.llm.GenerateChangelogGeneric(formatted, "", "")
 	if err != nil {
-		s.taskLog.logError(fmt.Sprintf("changelog failed: %v", err))
+		s.taskLog.logError(fmt.Sprintf("changelog generic failed: %v", err))
 		return "", []string{err.Error()}, false, err
 	}
 
-	md := formatChangelogByAreaMarkdown(changelog)
+	md := formatChangelogMarkdown(changelog)
+	s.taskLog.logChangelogDone(1)
+	return md, nil, false, nil
+}
+
+// generateWithAreas produces an area-based changelog when areas are configured.
+// Filters by IsExcluded, groups by area with group_N obfuscation, calls LLM,
+// then remaps group_N keys back to area names.
+func (s *ReleaseService) generateWithAreas(commits string) (string, []string, bool, error) {
+	filtered := filterForChangelog(commits, s.projectCfg)
+	if len(filtered) == 0 {
+		s.taskLog.logChangelogDone(0)
+		return "", nil, false, nil
+	}
+
+	areaGroups, nameMap := groupByArea(filtered, s.projectCfg)
+	if len(areaGroups) == 0 {
+		// No commits match any configured area — fall back to generic
+		return s.generateGeneric(commits)
+	}
+
+	formatted := FormatGroupedCommits(areaGroups)
+	changelog, err := s.llm.GenerateChangelogByArea(formatted)
+	if err != nil {
+		s.taskLog.logError(fmt.Sprintf("changelog by area failed: %v", err))
+		return "", []string{err.Error()}, false, err
+	}
+
+	// Remap group_N keys back to area names
+	remapped := remapGroupKeys(changelog, nameMap)
+	md := formatChangelogByAreaMarkdown(remapped)
 	s.taskLog.logChangelogDone(1)
 	return md, nil, false, nil
 }
@@ -116,4 +160,59 @@ func formatChangelogMarkdown(ch *domain.Changelog) string {
 		}
 	}
 	return strings.TrimSpace(sb.String())
+}
+
+// groupByArea maps scope-grouped commits to group_N keys for LLM obfuscation.
+// Areas are sorted alphabetically → group_1, group_2, etc.
+// Only scopes that match configured area names are included in area groups.
+// Returns the grouped map (keyed by group_N) and nameMap (group_N → area name).
+func groupByArea(groups map[string][]string, cfg *domain.ProjectConfig) (map[string][]string, map[string]string) {
+	if cfg == nil || len(cfg.Areas) == 0 {
+		return nil, nil
+	}
+
+	// Sort area names for deterministic group assignment
+	sortedAreas := make([]string, 0, len(cfg.Areas))
+	for area := range cfg.Areas {
+		sortedAreas = append(sortedAreas, area)
+	}
+	sort.Strings(sortedAreas)
+
+	// Build name map: area → group_N
+	areaToGroup := make(map[string]string)
+	nameMap := make(map[string]string)
+	for i, area := range sortedAreas {
+		groupKey := fmt.Sprintf("group_%d", i+1)
+		areaToGroup[area] = groupKey
+		nameMap[groupKey] = area
+	}
+
+	// Map commits from scope to group_N
+	result := make(map[string][]string)
+	for area, groupKey := range areaToGroup {
+		if commits, ok := groups[area]; ok {
+			result[groupKey] = commits
+		}
+	}
+	// Any scopeless commits go to a "general" group if present
+	if commits, ok := groups[""]; ok {
+		result["group_general"] = commits
+		nameMap["group_general"] = "general"
+	}
+
+	return result, nameMap
+}
+
+// remapGroupKeys replaces group_N keys in ChangelogByArea with the actual area names
+// using the nameMap obtained from groupByArea.
+func remapGroupKeys(ch domain.ChangelogByArea, nameMap map[string]string) domain.ChangelogByArea {
+	result := make(domain.ChangelogByArea)
+	for groupKey, items := range ch {
+		areaName, ok := nameMap[groupKey]
+		if !ok {
+			areaName = groupKey // fallback: keep group_N key
+		}
+		result[areaName] = items
+	}
+	return result
 }

--- a/internal/workflow/release_generate_test.go
+++ b/internal/workflow/release_generate_test.go
@@ -214,6 +214,12 @@ func (m *mockAreaLLM) GenerateChangelogByArea(formattedGroups string) (domain.Ch
 	m.called = formattedGroups
 	return m.result, m.err
 }
+func (m *mockAreaLLM) GenerateChangelogGeneric(commits, prev, out string) (*domain.Changelog, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &domain.Changelog{}, nil
+}
 func (m *mockAreaLLM) RegenerateMessage(prev []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
 	return nil, nil
 }
@@ -230,6 +236,12 @@ func TestGenerate_CallsGenerateChangelogByArea(t *testing.T) {
 
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
 	svc := NewReleaseService(git, llm, chunker, cfg, nil)
+	// Set areas to trigger by-area routing
+	svc.projectCfg = &domain.ProjectConfig{
+		Areas: map[string][]string{
+			"security": {"internal/auth"},
+		},
+	}
 
 	commits := "abc1234 fix(security): handle nil token"
 	changelog, warnings, isBg, err := svc.Generate(commits)
@@ -252,7 +264,7 @@ func TestGenerate_CallsGenerateChangelogByArea(t *testing.T) {
 
 func TestGenerate_AllInternalCommits_ReturnsEmpty(t *testing.T) {
 	git := &mockGitForRelease{}
-	llm := &mockAreaLLM{}
+	llm :=&mockAreaLLM{}
 	chunker := &mockLogChunker{}
 
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
@@ -282,6 +294,8 @@ func TestGenerate_LLMError_ReturnsWarning(t *testing.T) {
 
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
 	svc := NewReleaseService(git, llm, chunker, cfg, nil)
+	// Test generic path (nil areas) — generateGeneric should also return error
+	svc.projectCfg = nil
 
 	commits := "abc feat(core): add new feature"
 	_, warnings, _, err := svc.Generate(commits)
@@ -290,5 +304,285 @@ func TestGenerate_LLMError_ReturnsWarning(t *testing.T) {
 	}
 	if len(warnings) == 0 {
 		t.Error("expected warning on LLM failure")
+	}
+}
+
+// --- mockGenericLLM tracks both generic and by-area paths ---
+
+type mockGenericLLM struct {
+	genericResult *domain.Changelog
+	genericErr    error
+	genericCalled bool
+
+	byAreaResult domain.ChangelogByArea
+	byAreaErr     error
+	byAreaCalled  bool
+}
+
+func (m *mockGenericLLM) GenerateChunkMessage(chunk domain.DiffChunk) (string, error) { return "", nil }
+func (m *mockGenericLLM) DecideCommit(instruction, status, untracked, modified, deleted string) (domain.CommitIntent, error) {
+	return domain.CommitIntent{}, nil
+}
+func (m *mockGenericLLM) InterpretGitOp(op, instruction string, ctx map[string]string) (map[string]string, error) {
+	return nil, nil
+}
+func (m *mockGenericLLM) SetRetryContext(msg string)  {}
+func (m *mockGenericLLM) ClearRetryContext()           {}
+func (m *mockGenericLLM) IsAvailable() bool            { return true }
+func (m *mockGenericLLM) VerifySecrets(diff string, findings []domain.SecretDetection) (bool, error) {
+	return false, nil
+}
+func (m *mockGenericLLM) AuditBinaryContent(filename, content string) (bool, error) { return false, nil }
+func (m *mockGenericLLM) GenerateChangelog(commits, prev, out string) (*domain.Changelog, error) {
+	m.genericCalled = true
+	if m.genericErr != nil {
+		return nil, m.genericErr
+	}
+	return m.genericResult, nil
+}
+func (m *mockGenericLLM) GenerateChangelogByArea(formattedGroups string) (domain.ChangelogByArea, error) {
+	m.byAreaCalled = true
+	if m.byAreaErr != nil {
+		return nil, m.byAreaErr
+	}
+	return m.byAreaResult, nil
+}
+func (m *mockGenericLLM) GenerateChangelogGeneric(commits, previousChangelog, outputFile string) (*domain.Changelog, error) {
+	m.genericCalled = true
+	if m.genericErr != nil {
+		return nil, m.genericErr
+	}
+	return m.genericResult, nil
+}
+func (m *mockGenericLLM) RegenerateMessage(prev []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
+	return nil, nil
+}
+func (m *mockGenericLLM) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) { return nil, nil }
+func (m *mockGenericLLM) ClassifyBinary(prompt string) (string, error) {
+	return "fix", nil
+}
+
+// --- filterForChangelog tests ---
+
+func TestFilterForChangelog_ExcludesDocsAndInternal(t *testing.T) {
+	cfg := &domain.ProjectConfig{
+		Excluded: []string{"docs", "scripts"},
+	}
+	commits := "abc1234 feat(core): add feature\ndef5678 docs: update readme\nghi9012 chore(scripts): update build\njkl3456 fix(core): fix bug"
+	groups := filterForChangelog(commits, cfg)
+	// core should have both feat and fix
+	if len(groups["core"]) != 2 {
+		t.Errorf("core area: want 2 commits, got %d", len(groups["core"]))
+	}
+	// chore(scripts) has type "chore" (skipType) so filtered by skipTypes
+	if _, ok := groups["scripts"]; ok {
+		t.Error("scripts scope should be excluded (skipType chore)")
+	}
+	// docs: update readme has no scope and type "docs" (not skipType) so it passes
+	if len(groups[""]) != 1 {
+		t.Errorf("no-scope group: want 1 commit, got %d", len(groups[""]))
+	}
+	// Total non-excluded items: feat(core) + fix(core) + docs(empty scope) = 3
+	total := 0
+	for _, items := range groups {
+		total += len(items)
+	}
+	if total != 3 {
+		t.Errorf("expected 3 user-facing commits after filtering, got %d", total)
+	}
+}
+
+func TestFilterForChangelog_NilConfig_UsesDefaults(t *testing.T) {
+	// nil config means no scope-based exclusion (IsExcluded not called)
+	// but skipTypes still filters test/chore/ci/build
+	commits := "abc1234 feat: add feature\ndef5678 test: update tests\nghi9012 chore: update go.mod"
+	groups := filterForChangelog(commits, nil)
+	total := 0
+	for _, items := range groups {
+		total += len(items)
+	}
+	if total != 1 {
+		t.Errorf("expected 1 commit after filtering (test/chore skipped by type), got %d", total)
+	}
+}
+
+func TestFilterForChangelog_BreakingNotFiltered(t *testing.T) {
+	cfg := &domain.ProjectConfig{
+		Excluded: []string{},
+	}
+	commits := "abc1234 test!: breaking test must appear"
+	groups := filterForChangelog(commits, cfg)
+	if len(groups) == 0 {
+		t.Error("breaking test commit should not be filtered")
+	}
+}
+
+// --- groupByArea tests ---
+
+func TestGroupByArea_SortedMapping(t *testing.T) {
+	cfg := &domain.ProjectConfig{
+		Areas: map[string][]string{
+			"tui":    {"internal/ui"},
+			"core":   {"internal/core"},
+			"deploy": {"internal/deploy"},
+		},
+	}
+	// Note: groupByArea receives pre-filtered groups from FilterAndGroupCommits
+	// Keyed by conventional-commit scope (which is the area name from the area mapping)
+	groups := map[string][]string{
+		"core":   {"feat(core): add feature", "fix(core): fix bug"},
+		"tui":    {"feat(tui): add screen"},
+		"deploy": {"chore(deploy): update config"},
+	}
+
+	areaGroups, nameMap := groupByArea(groups, cfg)
+
+	// Areas should be sorted: core=group_1, deploy=group_2, tui=group_3
+	if len(areaGroups) != 3 {
+		t.Errorf("expected 3 area groups, got %d", len(areaGroups))
+	}
+	// areaGroups keys should be group_N
+	for key := range areaGroups {
+		if !strings.HasPrefix(key, "group_") {
+			t.Errorf("expected group_N key, got %q", key)
+		}
+	}
+	// nameMap should map group_N back to area names
+	if len(nameMap) != 3 {
+		t.Errorf("expected 3 name mappings, got %d", len(nameMap))
+	}
+	// Verify reverse mapping: group_1 → core (alphabetically first)
+	sortedAreas := []string{"core", "deploy", "tui"}
+	for i, area := range sortedAreas {
+		groupKey := fmt.Sprintf("group_%d", i+1)
+		if nameMap[groupKey] != area {
+			t.Errorf("nameMap[%q] = %q, want %q", groupKey, nameMap[groupKey], area)
+		}
+	}
+}
+
+func TestGroupByArea_EmptyAreas(t *testing.T) {
+	cfg := &domain.ProjectConfig{
+		Areas: map[string][]string{},
+	}
+	groups := map[string][]string{
+		"": {"feat: add feature"},
+	}
+	areaGroups, nameMap := groupByArea(groups, cfg)
+	if len(areaGroups) != 0 {
+		t.Errorf("expected 0 area groups with empty areas, got %d", len(areaGroups))
+	}
+	if len(nameMap) != 0 {
+		t.Errorf("expected 0 name mappings with empty areas, got %d", len(nameMap))
+	}
+}
+
+func TestGroupByArea_NilAreas(t *testing.T) {
+	cfg := &domain.ProjectConfig{}
+	groups := map[string][]string{
+		"": {"feat: add feature"},
+	}
+	areaGroups, _ := groupByArea(groups, cfg)
+	if len(areaGroups) != 0 {
+		t.Errorf("expected 0 area groups with nil areas, got %d", len(areaGroups))
+	}
+}
+
+// --- remapGroupKeys tests ---
+
+func TestRemapGroupKeys_GroupToArea(t *testing.T) {
+	ch := domain.ChangelogByArea{
+		"group_1": []string{"add feature", "fix bug"},
+		"group_2": []string{"update screen"},
+	}
+	nameMap := map[string]string{
+		"group_1": "core",
+		"group_2": "tui",
+	}
+
+	result := remapGroupKeys(ch, nameMap)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 areas, got %d", len(result))
+	}
+	if len(result["core"]) != 2 {
+		t.Errorf("expected 2 items in core, got %d", len(result["core"]))
+	}
+	if len(result["tui"]) != 1 {
+		t.Errorf("expected 1 item in tui, got %d", len(result["tui"]))
+	}
+	if _, ok := result["group_1"]; ok {
+		t.Error("group_1 key should not exist in result")
+	}
+}
+
+func TestRemapGroupKeys_EmptyInput(t *testing.T) {
+	ch := domain.ChangelogByArea{}
+	nameMap := map[string]string{}
+
+	result := remapGroupKeys(ch, nameMap)
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %d areas", len(result))
+	}
+}
+
+// --- Generate routing tests ---
+
+func TestGenerate_NilAreas_RoutesToGeneric(t *testing.T) {
+	// When ProjectConfig has no areas, Generate should use the generic (by-type) path
+	git := &mockGitForRelease{}
+	llm := &mockGenericLLM{
+		genericResult: &domain.Changelog{Features: []string{"add feature"}},
+	}
+	chunker := &mockLogChunker{}
+	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
+	svc := NewReleaseService(git, llm, chunker, cfg, nil)
+	// Set nil project config explicitly
+	svc.projectCfg = nil
+
+	commits := "abc feat: add feature"
+	changelog, warnings, _, err := svc.Generate(commits)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+	if len(warnings) > 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+	if !llm.genericCalled {
+		t.Error("GenerateChangelogGeneric should have been called when areas is nil")
+	}
+	if llm.byAreaCalled {
+		t.Error("GenerateChangelogByArea should NOT have been called when areas is nil")
+	}
+	if !strings.Contains(changelog, "## Features") {
+		t.Errorf("expected Features section in changelog, got:\n%s", changelog)
+	}
+}
+
+func TestGenerate_WithAreas_RoutesToByArea(t *testing.T) {
+	git := &mockGitForRelease{}
+	llm := &mockGenericLLM{
+		byAreaResult: domain.ChangelogByArea{"core": []string{"add feature"}},
+	}
+	chunker := &mockLogChunker{}
+	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
+	svc := NewReleaseService(git, llm, chunker, cfg, nil)
+	// Set project config with areas
+	svc.projectCfg = &domain.ProjectConfig{
+		Areas: map[string][]string{
+			"core": {"internal/core"},
+		},
+	}
+
+	commits := "abc feat(core): add feature"
+	_, _, _, err := svc.Generate(commits)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+	if !llm.byAreaCalled {
+		t.Error("GenerateChangelogByArea should have been called when areas is configured")
+	}
+	if llm.genericCalled {
+		t.Error("GenerateChangelogGeneric should NOT have been called when areas is configured")
 	}
 }

--- a/internal/workflow/release_test.go
+++ b/internal/workflow/release_test.go
@@ -198,6 +198,12 @@ func (m *mockLLMForRelease) GenerateChangelogByArea(formattedGroups string) (dom
 	}
 	return domain.ChangelogByArea{"general": []string{m.changelogResult}}, nil
 }
+func (m *mockLLMForRelease) GenerateChangelogGeneric(commits, previousChangelog, outputFile string) (*domain.Changelog, error) {
+	if m.changelogErr != nil {
+		return nil, m.changelogErr
+	}
+	return &domain.Changelog{Features: []string{m.changelogResult}}, nil
+}
 func (m *mockLLMForRelease) RegenerateMessage(previousMessages []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

MCP area_required/area_response protocol for unassigned directories + 3-state changelog routing (generic vs area-based) with group_N obfuscation.

This is **PR 2 of 3** for the area-system feature (stacked-to-develop).

## Changes

### MCP area flow (P3)
- Commit PREVIEW detects directories without area assignment via `NewDirectories()`
- Returns `area_required` JSON status with directories, existing_areas, and hint explaining WHY areas matter for changelog organization
- New `area_response` parameter on commit tool — agent passes JSON mapping, Go saves to config (append-only)
- `areaRequiredResponse`, `getStringAreaResponse`, `saveAreaResponse` helpers
- Detection runs before WriteTree — asks about areas before starting workflow

### Changelog 3-state routing (P4)
- `Generate` now routes based on `ProjectConfig.Areas`:
  - No areas → `generateGeneric` using `changelog_generate.md` (Features/Fixes/Breaking)
  - Has areas → `generateWithAreas` using `changelog_areas.md` with group_N keys
- `filterForChangelog` removes excluded paths and filters by commit type (chore/test/ci/build unless breaking)
- `groupByArea` with group_N obfuscation — LLM NEVER sees area names, only group_1, group_2
- `remapGroupKeys` maps group_N back to area names for markdown output
- `GenerateChangelogGeneric` added to LLM interface (+ all 7 mock implementations)

## Critical Design Decision
**LLM never sees area names.** Go groups by area, sends as group_1/group_2, LLM only translates. Go maps back after response. This prevents the LLM from confusing areas.

## Test Plan
- [x] areaRequiredResponse tests (3 cases)
- [x] getStringAreaResponse tests (3 cases)
- [x] filterForChangelog tests (5 cases)
- [x] groupByArea tests (5 cases)
- [x] remapGroupKeys tests (2 cases)
- [x] Generate routing tests (2 cases — generic vs area)
- [x] All mock LLM types updated
- [x] Full project builds: `go build ./...`
- [x] Pre-existing test failures (chunkers e2e, tui) are unrelated

## Next PR
- PR 3: LLM adapter group_N nameMap + chunked changelog calls