### PR TITLE
chore(ci): configure goreleaser to keep existing release description

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,7 +39,7 @@ checksum:
 
 release:
   prerelease: auto
-  mode: replace
+  mode: keep-existing
   header: |
     ## What's Changed
 


### PR DESCRIPTION
This changes GoReleaser mode to keep-existing to prevent it from overwriting the release description on GitHub.