### PR TITLE
fix(ci): ensure rust targets are installed for cross-compilation

### DIFF
--- a/.github/workflows/build-ffi-libs.yml
+++ b/.github/workflows/build-ffi-libs.yml
@@ -42,17 +42,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Rust (macOS Intel target)
+      - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          targets: x86_64-apple-darwin
 
       - name: Install alef
         run: cargo install alef
 
       - name: Generate FFI bindings
         run: |
+          rustup target add x86_64-apple-darwin
           git clone https://github.com/kreuzberg-dev/tree-sitter-language-pack.git
           cd tree-sitter-language-pack
           alef generate
@@ -101,10 +99,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Rust (GNU toolchain)
+      - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-pc-windows-gnu
 
       - name: Install alef
         run: cargo install alef
@@ -112,6 +108,7 @@ jobs:
       - name: Generate FFI bindings
         shell: bash
         run: |
+          rustup target add x86_64-pc-windows-gnu
           git clone https://github.com/kreuzberg-dev/tree-sitter-language-pack.git
           cd tree-sitter-language-pack
           alef generate


### PR DESCRIPTION
This fixes the FFI build by explicitly installing the required Rust targets in the runner before generation and building in release mode.