### PR TITLE
fix(ci): disable unsupported CGO cross-compilation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,11 @@ builds:
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: linux
+        goarch: arm64
+      - goos: windows
+        goarch: arm64
     ldflags:
       - -s -w
       - -X github.com/Alejandro-M-P/git-courer/internal/config.ServerVersion={{.Version}}


### PR DESCRIPTION
This PR fixes the release failure by disabling arm64 builds for Linux and Windows, which were causing CGO assembler errors in the CI runner. macOS arm64 is preserved.