### PR TITLE
fix(ci): add checkout step to release upload job

### DIFF
--- a/.github/workflows/build-ffi-libs.yml
+++ b/.github/workflows/build-ffi-libs.yml
@@ -145,6 +145,9 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download All Binaries
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The gh release upload command requires a git repository context. This PR adds the missing checkout step to the publish-release job.