### PR TITLE
feat: auto-stage metadata Phase 1 (Foundation)

### DIFF
--- a/internal/core/domain/metadata.go
+++ b/internal/core/domain/metadata.go
@@ -1,0 +1,13 @@
+package domain
+
+import (
+	"strings"
+)
+
+// MetadataDir defines the location of git-courer metadata files.
+const MetadataDir = ".git-courer"
+
+// IsMetadataPath returns true if the given path is the metadata directory or located within it.
+func IsMetadataPath(path string) bool {
+	return path == MetadataDir || strings.HasPrefix(path, MetadataDir+"/")
+}

--- a/internal/core/domain/metadata_test.go
+++ b/internal/core/domain/metadata_test.go
@@ -1,0 +1,39 @@
+package domain
+
+import (
+	"testing"
+)
+
+func TestIsMetadataPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{".git-courer", true},
+		{".git-courer/", true},
+		{".git-courer/config.json", true},
+		{".git-courer/branches/feat-add-pi/commits.json", true},
+		{"internal/core/domain/metadata.go", false},
+		{"git-courer", false},
+		{"foo/.git-courer", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			got := IsMetadataPath(tt.path)
+			if got != tt.want {
+				t.Errorf("IsMetadataPath(%q) = %v; want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMetadataDirConstant(t *testing.T) {
+	if MetadataDir != ".git-courer" {
+		t.Errorf("MetadataDir = %q; want %q", MetadataDir, ".git-courer")
+	}
+}

--- a/internal/infra/chunkers/diff.go
+++ b/internal/infra/chunkers/diff.go
@@ -70,10 +70,10 @@ func (c *DiffChunker) Chunk(diff string, maxChunkSize int) ([]domain.DiffChunk, 
 
 	parsedFiles, _, err := gitdiff.Parse(strings.NewReader(diff))
 
-	// Filter out test files (e.g. *_test.go, test_*.py, etc.) so they don't
-	// consume LLM context with redundant test logic. Uses language-specific
-	// test patterns from the catalog.
-	parsedFiles = c.filterTestFiles(parsedFiles)
+	// Filter out test files (e.g. *_test.go, test_*.py, etc.) and git-courer metadata files
+	// so they don't consume LLM context with redundant logic. Uses language-specific
+	// test patterns from the catalog and metadata path checker.
+	parsedFiles = c.filterExcludedFiles(parsedFiles)
 
 	// If parsing succeeded and all remaining files are tests (nothing to do),
 	// return early. When parsing fails, fall through to fallbackChunk which
@@ -117,16 +117,16 @@ func (c *DiffChunker) Chunk(diff string, maxChunkSize int) ([]domain.DiffChunk, 
 	return chunks, nil
 }
 
-// filterTestFiles removes test files from the parsed slice using the language
-// catalog's IsTestFile detection. Returns the filtered slice (same backing array).
-func (c *DiffChunker) filterTestFiles(files []*gitdiff.File) []*gitdiff.File {
+// filterExcludedFiles removes test files and git-courer metadata files from the parsed slice.
+// Returns the filtered slice (same backing array).
+func (c *DiffChunker) filterExcludedFiles(files []*gitdiff.File) []*gitdiff.File {
 	filtered := files[:0]
 	for _, f := range files {
 		name := c.getFileName(f)
 		if name == "" {
 			continue
 		}
-		if c.catalog.IsTestFile(name) {
+		if c.catalog.IsTestFile(name) || domain.IsMetadataPath(name) {
 			continue
 		}
 		filtered = append(filtered, f)
@@ -150,7 +150,7 @@ func (c *DiffChunker) fallbackChunk(diff string, maxChunkSize int) []domain.Diff
 	for _, line := range lines {
 		if m := fileRe.FindStringSubmatch(line); len(m) > 1 {
 			filename := m[1]
-			skipFile = c.catalog.IsTestFile(filename)
+			skipFile = c.catalog.IsTestFile(filename) || domain.IsMetadataPath(filename)
 			if !skipFile {
 				currentFiles = append(currentFiles, filename)
 			}

--- a/internal/infra/chunkers/diff_test.go
+++ b/internal/infra/chunkers/diff_test.go
@@ -216,6 +216,72 @@ diff --git a/auth_test.go b/auth_test.go
 	}
 }
 
+func TestDiffChunker_Chunk_FiltersMetadataFiles(t *testing.T) {
+	c := NewDiffChunker()
+
+	// Metadata files should be filtered out.
+	diff := `diff --git a/auth.go b/auth.go
+--- a/auth.go
++++ b/auth.go
+@@ -1 +1,3 @@
++ func Auth() {}
+diff --git a/.git-courer/config.json b/.git-courer/config.json
+--- a/.git-courer/config.json
++++ b/.git-courer/config.json
+@@ -1 +1,3 @@
++ { "some": "config" }
+diff --git a/.git-courer/branches/main/commits.json b/.git-courer/branches/main/commits.json
+--- a/.git-courer/branches/main/commits.json
++++ b/.git-courer/branches/main/commits.json
+@@ -1 +1,3 @@
++ []`
+
+	chunks, err := c.Chunk(diff, 4096)
+	if err != nil {
+		t.Fatalf("Chunk failed: %v", err)
+	}
+
+	if len(chunks) != 1 {
+		t.Errorf("Expected 1 chunk (code only), got %d", len(chunks))
+	} else {
+		for _, f := range chunks[0].Files {
+			if strings.HasPrefix(f, ".git-courer") {
+				t.Errorf("Metadata file %q should have been filtered out", f)
+			}
+		}
+	}
+}
+
+func TestDiffChunker_Chunk_FallbackFiltersMetadataFiles(t *testing.T) {
+	c := NewDiffChunker()
+
+	// Malformed diff to force fallback path
+	diff := `diff --git a/auth.go b/auth.go
+--- a/auth.go
++++ b/auth.go
++ func Auth() {}
+diff --git a/.git-courer/config.json b/.git-courer/config.json
+--- a/.git-courer/config.json
++++ b/.git-courer/config.json
++ { "some": "config" }`
+
+	chunks, err := c.Chunk(diff, 4096)
+	if err != nil {
+		t.Fatalf("Chunk failed: %v", err)
+	}
+
+	if len(chunks) != 1 {
+		t.Errorf("Expected 1 chunk (code only), got %d", len(chunks))
+	} else {
+		for _, f := range chunks[0].Files {
+			if strings.HasPrefix(f, ".git-courer") {
+				t.Errorf("Fallback metadata file %q should have been filtered out", f)
+			}
+		}
+	}
+}
+
+
 func TestDiffChunker_Chunk_FiltersPythonTestFiles(t *testing.T) {
 	c := NewDiffChunker()
 


### PR DESCRIPTION
This PR implements Phase 1 (Foundation) of the auto-stage-metadata change. It defines the MetadataDir constant and the IsMetadataPath utility function in the domain layer, renames filterTestFiles to filterExcludedFiles in the chunker, and updates it to exclude all files under .git-courer/ from LLM context.