### PR TITLE
feat(commitstore): implement Reconcile capability

### DIFF
--- a/internal/adapters/commitstore/adapter.go
+++ b/internal/adapters/commitstore/adapter.go
@@ -98,6 +98,12 @@ func (s *FilesystemCommitStore) Read() ([]domain.CommitEntry, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	return s.readLocked()
+}
+
+// readLocked reads entries from the store file without locking.
+// It assumes the caller holds the lock.
+func (s *FilesystemCommitStore) readLocked() ([]domain.CommitEntry, error) {
 	f, err := os.Open(s.path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -140,6 +146,91 @@ func (s *FilesystemCommitStore) Read() ([]domain.CommitEntry, error) {
 	}
 
 	return entries, nil
+}
+
+// write overwrites the store file with the provided entries.
+// It assumes the caller holds the lock.
+func (s *FilesystemCommitStore) write(entries []domain.CommitEntry) error {
+	if err := os.MkdirAll(s.currentDir, 0o755); err != nil {
+		return fmt.Errorf("commit store: create directory: %w", s.sanitizePathError(err))
+	}
+
+	f, err := os.OpenFile(s.path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("commit store: open file: %w", s.sanitizePathError(err))
+	}
+	defer f.Close()
+
+	writer := bufio.NewWriter(f)
+	for _, entry := range entries {
+		line := jsonEntry{
+			SHA:     entry.SHA(),
+			Message: entry.Message(),
+			Author:  entry.Author(),
+			Date:    entry.Date(),
+		}
+		data, err := json.Marshal(line)
+		if err != nil {
+			return fmt.Errorf("commit store: marshal entry: %w", err)
+		}
+		if _, err := writer.Write(data); err != nil {
+			return fmt.Errorf("commit store: write entry: %w", s.sanitizePathError(err))
+		}
+		if _, err := writer.WriteRune('\n'); err != nil {
+			return fmt.Errorf("commit store: write newline: %w", s.sanitizePathError(err))
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("commit store: flush: %w", s.sanitizePathError(err))
+	}
+
+	return nil
+}
+
+// Reconcile reconciles the store's entries with the current git log.
+// Stale entries (not in gitEntries) are removed, missing ones are added,
+// and modified entries are updated. The final store state will match gitEntries.
+// If the new state matches the existing file contents exactly, the write is skipped.
+func (s *FilesystemCommitStore) Reconcile(gitEntries []domain.CommitEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existing, err := s.readLocked()
+	if err != nil {
+		return fmt.Errorf("commit store reconcile: read: %w", err)
+	}
+
+	if len(existing) == 0 && len(gitEntries) == 0 {
+		if _, err := os.Stat(s.path); errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+	}
+
+	if s.entriesEqual(existing, gitEntries) {
+		return nil
+	}
+
+	if err := s.write(gitEntries); err != nil {
+		return fmt.Errorf("commit store reconcile: write: %w", err)
+	}
+
+	return nil
+}
+
+// entriesEqual checks if two slices of CommitEntry are identical in contents and order.
+func (s *FilesystemCommitStore) entriesEqual(a, b []domain.CommitEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].SHA() != b[i].SHA() ||
+			a[i].Message() != b[i].Message() ||
+			a[i].Author() != b[i].Author() ||
+			a[i].Date() != b[i].Date() {
+			return false
+		}
+	}
+	return true
 }
 
 // Clear truncates the file to zero bytes.

--- a/internal/adapters/commitstore/reconcile_test.go
+++ b/internal/adapters/commitstore/reconcile_test.go
@@ -1,0 +1,159 @@
+package commitstore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Alejandro-M-P/git-courer/internal/core/domain"
+)
+
+func TestFilesystemCommitStore_Reconcile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Reconcile empty store with empty git log is no-op", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		store := NewFilesystemCommitStore(tmpDir)
+
+		err := store.Reconcile([]domain.CommitEntry{})
+		if err != nil {
+			t.Fatalf("Reconcile empty error: %v", err)
+		}
+
+		// Verify no file was created
+		filePath := filepath.Join(tmpDir, ".git-courer", "commits.json")
+		if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+			t.Errorf("expected no file to be created for empty reconcile, but it exists")
+		}
+	})
+
+	t.Run("Reconcile add missing entries to empty store", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		store := NewFilesystemCommitStore(tmpDir)
+
+		gitEntries := []domain.CommitEntry{
+			makeEntry(t, validSHA("1111"), "feat: add user auth"),
+			makeEntry(t, validSHA("2222"), "fix: session timeout"),
+		}
+
+		err := store.Reconcile(gitEntries)
+		if err != nil {
+			t.Fatalf("Reconcile error: %v", err)
+		}
+
+		// Read and verify
+		readEntries, err := store.Read()
+		if err != nil {
+			t.Fatalf("Read error: %v", err)
+		}
+		if len(readEntries) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(readEntries))
+		}
+		if readEntries[0].SHA() != gitEntries[0].SHA() || readEntries[1].SHA() != gitEntries[1].SHA() {
+			t.Errorf("SHAs do not match")
+		}
+	})
+
+	t.Run("Reconcile delete stale entries and keep matching ones", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		store := NewFilesystemCommitStore(tmpDir)
+
+		e1 := makeEntry(t, validSHA("1111"), "feat: add user auth")
+		e2 := makeEntry(t, validSHA("2222"), "fix: session timeout")
+		e3 := makeEntry(t, validSHA("3333"), "docs: update readme")
+
+		// Write e1, e2, e3
+		if err := store.Append(e1, e2, e3); err != nil {
+			t.Fatalf("Append error: %v", err)
+		}
+
+		// Reconcile with only e1 and e3 (e2 is stale/removed)
+		gitEntries := []domain.CommitEntry{e1, e3}
+		if err := store.Reconcile(gitEntries); err != nil {
+			t.Fatalf("Reconcile error: %v", err)
+		}
+
+		// Read and verify
+		readEntries, err := store.Read()
+		if err != nil {
+			t.Fatalf("Read error: %v", err)
+		}
+		if len(readEntries) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(readEntries))
+		}
+		if readEntries[0].SHA() != e1.SHA() || readEntries[1].SHA() != e3.SHA() {
+			t.Errorf("expected e1 and e3, got different entries")
+		}
+	})
+
+	t.Run("Reconcile update modified entries", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		store := NewFilesystemCommitStore(tmpDir)
+
+		e1 := makeEntry(t, validSHA("1111"), "feat: add user auth")
+		if err := store.Append(e1); err != nil {
+			t.Fatalf("Append error: %v", err)
+		}
+
+		// Reconcile with updated message
+		e1Updated := makeEntry(t, validSHA("1111"), "feat: add user authentication")
+		if err := store.Reconcile([]domain.CommitEntry{e1Updated}); err != nil {
+			t.Fatalf("Reconcile error: %v", err)
+		}
+
+		readEntries, err := store.Read()
+		if err != nil {
+			t.Fatalf("Read error: %v", err)
+		}
+		if len(readEntries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(readEntries))
+		}
+		if readEntries[0].Message() != "feat: add user authentication" {
+			t.Errorf("expected updated message, got %q", readEntries[0].Message())
+		}
+	})
+
+	t.Run("Reconcile skips write if contents are identical", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		store := NewFilesystemCommitStore(tmpDir)
+
+		e1 := makeEntry(t, validSHA("1111"), "feat: add user auth")
+		e2 := makeEntry(t, validSHA("2222"), "fix: session timeout")
+		if err := store.Append(e1, e2); err != nil {
+			t.Fatalf("Append error: %v", err)
+		}
+
+		filePath := filepath.Join(tmpDir, ".git-courer", "commits.json")
+
+		// Change file permissions to 0400 (read-only)
+		if err := os.Chmod(filePath, 0400); err != nil {
+			t.Fatalf("Chmod error: %v", err)
+		}
+		defer func() {
+			_ = os.Chmod(filePath, 0644)
+		}()
+
+		// Reconcile with identical entries should succeed (skips write)
+		if err := store.Reconcile([]domain.CommitEntry{e1, e2}); err != nil {
+			t.Fatalf("Reconcile on read-only identical file failed: %v", err)
+		}
+
+		// Restore write permissions
+		if err := os.Chmod(filePath, 0644); err != nil {
+			t.Fatalf("Chmod restore error: %v", err)
+		}
+
+		// Reconcile with different entries (needs write) should succeed now
+		if err := store.Reconcile([]domain.CommitEntry{e1}); err != nil {
+			t.Fatalf("Reconcile write failed: %v", err)
+		}
+
+		readEntries, err := store.Read()
+		if err != nil {
+			t.Fatalf("Read error: %v", err)
+		}
+		if len(readEntries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(readEntries))
+		}
+	})
+}

--- a/internal/core/domain/metadata.go
+++ b/internal/core/domain/metadata.go
@@ -1,0 +1,13 @@
+package domain
+
+import (
+	"strings"
+)
+
+// MetadataDir defines the location of git-courer metadata files.
+const MetadataDir = ".git-courer"
+
+// IsMetadataPath returns true if the given path is the metadata directory or located within it.
+func IsMetadataPath(path string) bool {
+	return path == MetadataDir || strings.HasPrefix(path, MetadataDir+"/")
+}

--- a/internal/core/domain/metadata_test.go
+++ b/internal/core/domain/metadata_test.go
@@ -1,0 +1,39 @@
+package domain
+
+import (
+	"testing"
+)
+
+func TestIsMetadataPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{".git-courer", true},
+		{".git-courer/", true},
+		{".git-courer/config.json", true},
+		{".git-courer/branches/feat-add-pi/commits.json", true},
+		{"internal/core/domain/metadata.go", false},
+		{"git-courer", false},
+		{"foo/.git-courer", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			got := IsMetadataPath(tt.path)
+			if got != tt.want {
+				t.Errorf("IsMetadataPath(%q) = %v; want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMetadataDirConstant(t *testing.T) {
+	if MetadataDir != ".git-courer" {
+		t.Errorf("MetadataDir = %q; want %q", MetadataDir, ".git-courer")
+	}
+}

--- a/internal/core/ports/commit_store.go
+++ b/internal/core/ports/commit_store.go
@@ -39,4 +39,10 @@ type CommitStore interface {
 	// If name is empty, returns an error.
 	// Thread-safe: serialized by the adapter's mutex.
 	RemoveBranch(name string) error
+
+	// Reconcile reconciles the store's entries with the current git log.
+	// Stale entries (not in gitEntries) are removed, missing ones are added,
+	// and modified entries are updated. The final store state will match gitEntries.
+	// If the new state matches the existing file contents exactly, the write is skipped.
+	Reconcile(gitEntries []domain.CommitEntry) error
 }

--- a/internal/core/ports/commit_store_test.go
+++ b/internal/core/ports/commit_store_test.go
@@ -31,6 +31,11 @@ func (m *mockCommitStore) RemoveBranch(name string) error {
 	return nil
 }
 
+func (m *mockCommitStore) Reconcile(gitEntries []domain.CommitEntry) error {
+	m.appended = gitEntries
+	return nil
+}
+
 // Compile-time interface satisfaction check.
 // This will fail to compile if CommitStore is not correctly defined
 // or if mockCommitStore doesn't implement all methods.

--- a/internal/delivery/cli/release_test.go
+++ b/internal/delivery/cli/release_test.go
@@ -93,6 +93,10 @@ func (m *mockCommitStoreForCLI) RemoveBranch(name string) error {
 	m.removeBranch = name
 	return nil
 }
+func (m *mockCommitStoreForCLI) Reconcile(gitEntries []domain.CommitEntry) error {
+	m.appended = gitEntries
+	return nil
+}
 
 // Compile-time check
 var _ ports.CommitStore = (*mockCommitStoreForCLI)(nil)

--- a/internal/infra/chunkers/diff.go
+++ b/internal/infra/chunkers/diff.go
@@ -70,10 +70,10 @@ func (c *DiffChunker) Chunk(diff string, maxChunkSize int) ([]domain.DiffChunk, 
 
 	parsedFiles, _, err := gitdiff.Parse(strings.NewReader(diff))
 
-	// Filter out test files (e.g. *_test.go, test_*.py, etc.) so they don't
-	// consume LLM context with redundant test logic. Uses language-specific
-	// test patterns from the catalog.
-	parsedFiles = c.filterTestFiles(parsedFiles)
+	// Filter out test files (e.g. *_test.go, test_*.py, etc.) and git-courer metadata files
+	// so they don't consume LLM context with redundant logic. Uses language-specific
+	// test patterns from the catalog and metadata path checker.
+	parsedFiles = c.filterExcludedFiles(parsedFiles)
 
 	// If parsing succeeded and all remaining files are tests (nothing to do),
 	// return early. When parsing fails, fall through to fallbackChunk which
@@ -117,16 +117,16 @@ func (c *DiffChunker) Chunk(diff string, maxChunkSize int) ([]domain.DiffChunk, 
 	return chunks, nil
 }
 
-// filterTestFiles removes test files from the parsed slice using the language
-// catalog's IsTestFile detection. Returns the filtered slice (same backing array).
-func (c *DiffChunker) filterTestFiles(files []*gitdiff.File) []*gitdiff.File {
+// filterExcludedFiles removes test files and git-courer metadata files from the parsed slice.
+// Returns the filtered slice (same backing array).
+func (c *DiffChunker) filterExcludedFiles(files []*gitdiff.File) []*gitdiff.File {
 	filtered := files[:0]
 	for _, f := range files {
 		name := c.getFileName(f)
 		if name == "" {
 			continue
 		}
-		if c.catalog.IsTestFile(name) {
+		if c.catalog.IsTestFile(name) || domain.IsMetadataPath(name) {
 			continue
 		}
 		filtered = append(filtered, f)
@@ -150,7 +150,7 @@ func (c *DiffChunker) fallbackChunk(diff string, maxChunkSize int) []domain.Diff
 	for _, line := range lines {
 		if m := fileRe.FindStringSubmatch(line); len(m) > 1 {
 			filename := m[1]
-			skipFile = c.catalog.IsTestFile(filename)
+			skipFile = c.catalog.IsTestFile(filename) || domain.IsMetadataPath(filename)
 			if !skipFile {
 				currentFiles = append(currentFiles, filename)
 			}

--- a/internal/infra/chunkers/diff_test.go
+++ b/internal/infra/chunkers/diff_test.go
@@ -216,6 +216,72 @@ diff --git a/auth_test.go b/auth_test.go
 	}
 }
 
+func TestDiffChunker_Chunk_FiltersMetadataFiles(t *testing.T) {
+	c := NewDiffChunker()
+
+	// Metadata files should be filtered out.
+	diff := `diff --git a/auth.go b/auth.go
+--- a/auth.go
++++ b/auth.go
+@@ -1 +1,3 @@
++ func Auth() {}
+diff --git a/.git-courer/config.json b/.git-courer/config.json
+--- a/.git-courer/config.json
++++ b/.git-courer/config.json
+@@ -1 +1,3 @@
++ { "some": "config" }
+diff --git a/.git-courer/branches/main/commits.json b/.git-courer/branches/main/commits.json
+--- a/.git-courer/branches/main/commits.json
++++ b/.git-courer/branches/main/commits.json
+@@ -1 +1,3 @@
++ []`
+
+	chunks, err := c.Chunk(diff, 4096)
+	if err != nil {
+		t.Fatalf("Chunk failed: %v", err)
+	}
+
+	if len(chunks) != 1 {
+		t.Errorf("Expected 1 chunk (code only), got %d", len(chunks))
+	} else {
+		for _, f := range chunks[0].Files {
+			if strings.HasPrefix(f, ".git-courer") {
+				t.Errorf("Metadata file %q should have been filtered out", f)
+			}
+		}
+	}
+}
+
+func TestDiffChunker_Chunk_FallbackFiltersMetadataFiles(t *testing.T) {
+	c := NewDiffChunker()
+
+	// Malformed diff to force fallback path
+	diff := `diff --git a/auth.go b/auth.go
+--- a/auth.go
++++ b/auth.go
++ func Auth() {}
+diff --git a/.git-courer/config.json b/.git-courer/config.json
+--- a/.git-courer/config.json
++++ b/.git-courer/config.json
++ { "some": "config" }`
+
+	chunks, err := c.Chunk(diff, 4096)
+	if err != nil {
+		t.Fatalf("Chunk failed: %v", err)
+	}
+
+	if len(chunks) != 1 {
+		t.Errorf("Expected 1 chunk (code only), got %d", len(chunks))
+	} else {
+		for _, f := range chunks[0].Files {
+			if strings.HasPrefix(f, ".git-courer") {
+				t.Errorf("Fallback metadata file %q should have been filtered out", f)
+			}
+		}
+	}
+}
+
+
 func TestDiffChunker_Chunk_FiltersPythonTestFiles(t *testing.T) {
 	c := NewDiffChunker()
 

--- a/internal/workflow/commit_capture_test.go
+++ b/internal/workflow/commit_capture_test.go
@@ -47,6 +47,13 @@ func (m *mockCommitStore) RemoveBranch(name string) error {
 	return nil
 }
 
+func (m *mockCommitStore) Reconcile(gitEntries []domain.CommitEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.appended = gitEntries
+	return nil
+}
+
 // captureTestGit extends stubGit to return a proper SHA from Head() and author from ConfigGet.
 type captureTestGit struct {
 	stubGit

--- a/internal/workflow/release_capture_test.go
+++ b/internal/workflow/release_capture_test.go
@@ -55,6 +55,13 @@ func (m *releaseStoreMock) RemoveBranch(name string) error {
 	return nil
 }
 
+func (m *releaseStoreMock) Reconcile(gitEntries []domain.CommitEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries = gitEntries
+	return nil
+}
+
 // --- Phase 4.1 RED: Prepare with CommitStore ---
 
 func TestReleaseService_Prepare_UsesCommitStoreEntries(t *testing.T) {


### PR DESCRIPTION
This PR implements Phase 2: Persistence (CommitStore Reconcile) of the auto-stage-metadata capability. It adds Reconcile to ports.CommitStore, implements the diff/reconciliation logic in the filesystem adapter, extracts I/O helpers, and updates all tests/mocks to satisfy the interface.