### PR TITLE
ci: compile Windows FFI from source with bug patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Remove stale directory if Cargo cache restored target/ but source cache missed
+          rm -rf tree-sitter-language-pack
           LATEST_STABLE=$(gh api repos/kreuzberg-dev/tree-sitter-language-pack/releases --jq '[.[] | select(.prerelease == false)] | .[0].tag_name')
           echo "Latest stable: $LATEST_STABLE"
           git clone --branch "$LATEST_STABLE" --depth 1 https://github.com/kreuzberg-dev/tree-sitter-language-pack.git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,18 +112,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          git clone https://github.com/kreuzberg-dev/tree-sitter-language-pack.git
+          LATEST_STABLE=$(gh api repos/kreuzberg-dev/tree-sitter-language-pack/releases --jq '[.[] | select(.prerelease == false)] | .[0].tag_name')
+          echo "Latest stable: $LATEST_STABLE"
+          git clone --branch "$LATEST_STABLE" --depth 1 https://github.com/kreuzberg-dev/tree-sitter-language-pack.git
           cd tree-sitter-language-pack
           rm -f rust-toolchain.toml rust-toolchain
           cargo install alef
           alef generate
-
-      - name: Patch FFI for GNU target compatibility
-        shell: bash
-        run: |
-          cd tree-sitter-language-pack
-          # Fix mismatched types bug: result is Result<DownloadManager, Error>, not DownloadManager
-          sed -i 's/Box::into_raw(Box::new(result))/Box::into_raw(Box::new(result.expect("Failed to create DownloadManager")))/' crates/ts-pack-core-ffi/src/lib.rs
 
       - name: Build FFI library (GNU target)
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,13 +83,55 @@ jobs:
           go-version: '1.26'
           cache: true
 
-      - name: Download FFI
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-gnu
+
+      - name: Cache FFI source code
+        id: cache-ts-source
+        uses: actions/cache@v4
+        with:
+          path: tree-sitter-language-pack
+          key: windows-ts-source-v2
+          restore-keys: windows-ts-source-v2
+
+      - name: Cache Cargo build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            tree-sitter-language-pack/target
+          key: ${{ runner.os }}-cargo-ts-v2-${{ hashFiles('tree-sitter-language-pack/**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-ts-v2-
+
+      - name: Clone and generate FFI (cache miss only)
+        if: steps.cache-ts-source.outputs.cache-hit != 'true'
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+        run: |
+          git clone https://github.com/kreuzberg-dev/tree-sitter-language-pack.git
+          cd tree-sitter-language-pack
+          rm -f rust-toolchain.toml rust-toolchain
+          cargo install alef
+          alef generate
+
+      - name: Patch FFI for GNU target compatibility
         shell: bash
         run: |
-          chmod +x scripts/update-ffi.sh
-          ./scripts/update-ffi.sh
+          cd tree-sitter-language-pack
+          # Fix mismatched types bug: result is Result<DownloadManager, Error>, not DownloadManager
+          sed -i 's/Box::into_raw(Box::new(result))/Box::into_raw(Box::new(result.expect("Failed to create DownloadManager")))/' crates/ts-pack-core-ffi/src/lib.rs
+
+      - name: Build FFI library (GNU target)
+        shell: bash
+        run: |
+          cd tree-sitter-language-pack
+          cargo build --release -p ts-pack-core-ffi --target x86_64-pc-windows-gnu
+          mkdir -p ../target/release/windows_amd64
+          cp target/x86_64-pc-windows-gnu/release/libts_pack_core_ffi.a ../target/release/windows_amd64/libts_pack_core_ffi.a
 
       - name: Build Binary
         run: |

--- a/scripts/update-ffi.sh
+++ b/scripts/update-ffi.sh
@@ -6,9 +6,9 @@ REPO="kreuzberg-dev/tree-sitter-language-pack"
 EXT_LIB_DIR="internal/infra/chunkers/ext_lib"
 TARGET_BASE="target/release"
 
-echo "🔍 Fetching latest release tag from $REPO..."
-LATEST_TAG=$(gh api repos/$REPO/releases --jq '.[0].tag_name')
-echo "✅ Latest version found: $LATEST_TAG"
+echo "🔍 Fetching latest stable release tag from $REPO..."
+LATEST_TAG=$(gh api repos/$REPO/releases --jq '[.[] | select(.prerelease == false)] | .[0].tag_name')
+echo "✅ Latest stable version: $LATEST_TAG"
 
 mkdir -p "$TARGET_BASE/linux_amd64"
 mkdir -p "$TARGET_BASE/darwin_amd64"


### PR DESCRIPTION
Closes #110

## Summary

- Reverted to source compilation for Windows FFI (pre-compiled Go packages are MSVC-only, incompatible with CGO's MinGW/gcc)
- Added sed patch for mismatched types bug in tree-sitter-language-pack v1.9.0-rc.17
- Updated cache keys to avoid stale broken cache