### PR TITLE
feat: stack detection on CommitEntry (stacks v2.2 phase 2)

### DIFF
--- a/.git-courer/branches/stacks-v2.2-phase2/commits.json
+++ b/.git-courer/branches/stacks-v2.2-phase2/commits.json
@@ -1,0 +1,38 @@
+[
+  {
+    "sha": "ecb1b508d89f524535dff5f965390fc35146bb2f",
+    "message": "chore: add CI release configuration for native binaries",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "b6c97679b0701b7fece79a776abb2aeaffd474bb",
+    "message": "fix: add SymbolicRef to git mocks and ignore local config",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "27e3bcbc3962acfe67f2810789393176e6809c56",
+    "message": "chore: add SymbolicRef to all Git mock implementations",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "7648371b200d4b8adb23da85f017f97ff41ad196",
+    "message": "feat(domain): add DetectBaseBranch helper and SymbolicRef port",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "8ad287cebf8d1ac4941a3d334e1ff13b11567b13",
+    "message": "feat(handler): replace hardcoded base branch list with ProjectConfig.BaseBranch",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "889c0550d20bce04706698f9fac1e757f69f41b0",
+    "message": "feat(domain): add BaseBranch field to ProjectConfig",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  }
+]

--- a/.gitignore
+++ b/.gitignore
@@ -95,4 +95,4 @@ test/release/audit/
 
 # CI release: downloaded native binaries for gh release upload
 native-binaries/
-
+.git-courer/

--- a/.gitignore
+++ b/.gitignore
@@ -95,4 +95,4 @@ test/release/audit/
 
 # CI release: downloaded native binaries for gh release upload
 native-binaries/
-.git-courer/
+

--- a/internal/adapters/commitstore/adapter.go
+++ b/internal/adapters/commitstore/adapter.go
@@ -18,10 +18,12 @@ import (
 
 // jsonEntry is the JSON serialization format for CommitEntry.
 type jsonEntry struct {
-	SHA     string `json:"sha"`
-	Message string `json:"message"`
-	Author  string `json:"author"`
-	Date    string `json:"date"`
+	SHA         string `json:"sha"`
+	Message     string `json:"message"`
+	Author      string `json:"author"`
+	Date        string `json:"date"`
+	StackID     string `json:"stack_id,omitempty"`
+	StackBranch string `json:"stack_branch,omitempty"`
 }
 
 // FilesystemCommitStore implements ports.CommitStore using a JSONL file.
@@ -68,10 +70,12 @@ func (s *FilesystemCommitStore) Append(entries ...domain.CommitEntry) error {
 	var jsonEntries []jsonEntry
 	for _, entry := range combined {
 		jsonEntries = append(jsonEntries, jsonEntry{
-			SHA:     entry.SHA(),
-			Message: entry.Message(),
-			Author:  entry.Author(),
-			Date:    entry.Date(),
+			SHA:         entry.SHA(),
+			Message:     entry.Message(),
+			Author:      entry.Author(),
+			Date:        entry.Date(),
+			StackID:     entry.StackID(),
+			StackBranch: entry.StackBranch(),
 		})
 	}
 
@@ -121,6 +125,8 @@ func (s *FilesystemCommitStore) readLocked() ([]domain.CommitEntry, error) {
 			entry, err := domain.NewCommitEntry(je.SHA, je.Message,
 				domain.WithAuthor(je.Author),
 				domain.WithDate(je.Date),
+				domain.WithStackID(je.StackID),
+				domain.WithStackBranch(je.StackBranch),
 			)
 			if err != nil {
 				log.Printf("commit store: skipping invalid entry: %v", err)
@@ -152,6 +158,8 @@ func (s *FilesystemCommitStore) readLocked() ([]domain.CommitEntry, error) {
 		entry, err := domain.NewCommitEntry(je.SHA, je.Message,
 			domain.WithAuthor(je.Author),
 			domain.WithDate(je.Date),
+			domain.WithStackID(je.StackID),
+			domain.WithStackBranch(je.StackBranch),
 		)
 		if err != nil {
 			log.Printf("commit store: skipping invalid entry at line %d: %v", lineNum, err)
@@ -178,10 +186,12 @@ func (s *FilesystemCommitStore) write(entries []domain.CommitEntry) error {
 	var jsonEntries []jsonEntry
 	for _, entry := range entries {
 		jsonEntries = append(jsonEntries, jsonEntry{
-			SHA:     entry.SHA(),
-			Message: entry.Message(),
-			Author:  entry.Author(),
-			Date:    entry.Date(),
+			SHA:         entry.SHA(),
+			Message:     entry.Message(),
+			Author:      entry.Author(),
+			Date:        entry.Date(),
+			StackID:     entry.StackID(),
+			StackBranch: entry.StackBranch(),
 		})
 	}
 
@@ -237,7 +247,9 @@ func (s *FilesystemCommitStore) entriesEqual(a, b []domain.CommitEntry) bool {
 		if a[i].SHA() != b[i].SHA() ||
 			a[i].Message() != b[i].Message() ||
 			a[i].Author() != b[i].Author() ||
-			a[i].Date() != b[i].Date() {
+			a[i].Date() != b[i].Date() ||
+			a[i].StackID() != b[i].StackID() ||
+			a[i].StackBranch() != b[i].StackBranch() {
 			return false
 		}
 	}
@@ -375,6 +387,8 @@ func (s *FilesystemCommitStore) ReadAllBranches() (map[string][]domain.CommitEnt
 			e, err := domain.NewCommitEntry(je.SHA, je.Message,
 				domain.WithAuthor(je.Author),
 				domain.WithDate(je.Date),
+				domain.WithStackID(je.StackID),
+				domain.WithStackBranch(je.StackBranch),
 			)
 			if err != nil {
 				log.Printf("[WARN] commit store: skipping invalid entry in branch %q: %v", branchName, err)

--- a/internal/adapters/commitstore/adapter_test.go
+++ b/internal/adapters/commitstore/adapter_test.go
@@ -811,6 +811,146 @@ func TestFilesystemCommitStore_JSONFormatAndFallback(t *testing.T) {
 	})
 }
 
+func TestFilesystemCommitStore_StackFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("entries with StackID and StackBranch round-trip correctly", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		store := NewFilesystemCommitStore(tmpDir)
+
+		e1 := makeEntry(t, validSHA("a1000000000000000000000000000000000000"), "feat: first",
+			domain.WithAuthor("Alice"),
+			domain.WithDate("2026-06-01T12:00:00Z"),
+			domain.WithStackID("abc123def456789012345678901234567890abcd"),
+			domain.WithStackBranch("feature/auth"),
+		)
+		e2 := makeEntry(t, validSHA("b2000000000000000000000000000000000000"), "fix: second",
+			domain.WithStackID("abc123def456789012345678901234567890abcd"),
+			domain.WithStackBranch("feature/auth"),
+		)
+
+		if err := store.Append(e1, e2); err != nil {
+			t.Fatalf("Append() error: %v", err)
+		}
+
+		entries, err := store.Read()
+		if err != nil {
+			t.Fatalf("Read() error: %v", err)
+		}
+		if len(entries) != 2 {
+			t.Fatalf("Read() returned %d entries, want 2", len(entries))
+		}
+
+		if entries[0].StackID() != "abc123def456789012345678901234567890abcd" {
+			t.Errorf("entries[0].StackID() = %q, want %q", entries[0].StackID(), "abc123def456789012345678901234567890abcd")
+		}
+		if entries[0].StackBranch() != "feature/auth" {
+			t.Errorf("entries[0].StackBranch() = %q, want %q", entries[0].StackBranch(), "feature/auth")
+		}
+		if entries[1].StackID() != "abc123def456789012345678901234567890abcd" {
+			t.Errorf("entries[1].StackID() = %q, want %q", entries[1].StackID(), "abc123def456789012345678901234567890abcd")
+		}
+		if entries[1].StackBranch() != "feature/auth" {
+			t.Errorf("entries[1].StackBranch() = %q, want %q", entries[1].StackBranch(), "feature/auth")
+		}
+	})
+
+	t.Run("entries without stack fields default to empty strings", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		store := NewFilesystemCommitStore(tmpDir)
+
+		e1 := makeEntry(t, validSHA("c3000000000000000000000000000000000000"), "chore: no stack",
+			domain.WithAuthor("Bob"),
+		)
+
+		if err := store.Append(e1); err != nil {
+			t.Fatalf("Append() error: %v", err)
+		}
+
+		entries, err := store.Read()
+		if err != nil {
+			t.Fatalf("Read() error: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("Read() returned %d entries, want 1", len(entries))
+		}
+
+		if entries[0].StackID() != "" {
+			t.Errorf("entries[0].StackID() = %q, want empty string", entries[0].StackID())
+		}
+		if entries[0].StackBranch() != "" {
+			t.Errorf("entries[0].StackBranch() = %q, want empty string", entries[0].StackBranch())
+		}
+	})
+
+	t.Run("old commits.json without stack fields loads as empty strings", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		// Manually write a JSON file that has no stack_id or stack_branch fields
+		dirPath := filepath.Join(tmpDir, ".git-courer")
+		if err := os.MkdirAll(dirPath, 0o755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+
+		oldJSON := `[{"sha":"a100000000000000000000000000000000000000","message":"feat: old format","author":"Alice","date":"2026-05-01T10:00:00Z"}]` + "\n"
+		filePath := filepath.Join(dirPath, "commits.json")
+		if err := os.WriteFile(filePath, []byte(oldJSON), 0o644); err != nil {
+			t.Fatalf("WriteFile() error: %v", err)
+		}
+
+		store := NewFilesystemCommitStore(tmpDir)
+		entries, err := store.Read()
+		if err != nil {
+			t.Fatalf("Read() error: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("Read() returned %d entries, want 1", len(entries))
+		}
+		if entries[0].StackID() != "" {
+			t.Errorf("old format entries[0].StackID() = %q, want empty string", entries[0].StackID())
+		}
+		if entries[0].StackBranch() != "" {
+			t.Errorf("old format entries[0].StackBranch() = %q, want empty string", entries[0].StackBranch())
+		}
+		if entries[0].SHA() != "a100000000000000000000000000000000000000" {
+			t.Errorf("old format entries[0].SHA() = %q, want preserved SHA", entries[0].SHA())
+		}
+		if entries[0].Message() != "feat: old format" {
+			t.Errorf("old format entries[0].Message() = %q, want preserved message", entries[0].Message())
+		}
+		if entries[0].Author() != "Alice" {
+			t.Errorf("old format entries[0].Author() = %q, want preserved author", entries[0].Author())
+		}
+	})
+
+	t.Run("reconcile preserves stack fields", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		store := NewFilesystemCommitStore(tmpDir)
+
+		e1 := makeEntry(t, validSHA("d4000000000000000000000000000000000000"), "feat: stack entry",
+			domain.WithStackID("mergebaseSHA0000000000000000000000000000"),
+			domain.WithStackBranch("feature/login"),
+		)
+
+		if err := store.Reconcile([]domain.CommitEntry{e1}); err != nil {
+			t.Fatalf("Reconcile() error: %v", err)
+		}
+
+		entries, err := store.Read()
+		if err != nil {
+			t.Fatalf("Read() error: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("Read() returned %d entries, want 1", len(entries))
+		}
+		if entries[0].StackID() != "mergebaseSHA0000000000000000000000000000" {
+			t.Errorf("entries[0].StackID() = %q, want %q", entries[0].StackID(), "mergebaseSHA0000000000000000000000000000")
+		}
+		if entries[0].StackBranch() != "feature/login" {
+			t.Errorf("entries[0].StackBranch() = %q, want %q", entries[0].StackBranch(), "feature/login")
+		}
+	})
+}
+
 // --- ReadAllBranches tests ---
 
 func TestFilesystemCommitStore_ReadAllBranches_EmptyDir(t *testing.T) {

--- a/internal/core/domain/commit_entry.go
+++ b/internal/core/domain/commit_entry.go
@@ -16,8 +16,10 @@ var (
 
 // commitEntryConfig holds optional configuration for CommitEntry construction.
 type commitEntryConfig struct {
-	author string
-	date   string
+	author      string
+	date        string
+	stackID     string
+	stackBranch string
 }
 
 // CommitEntryOption is a functional option for CommitEntry construction.
@@ -37,14 +39,30 @@ func WithDate(d string) CommitEntryOption {
 	}
 }
 
+// WithStackID sets the stack ID (merge-base SHA) on a CommitEntry.
+func WithStackID(id string) CommitEntryOption {
+	return func(c *commitEntryConfig) {
+		c.stackID = id
+	}
+}
+
+// WithStackBranch sets the stack branch (current branch name) on a CommitEntry.
+func WithStackBranch(branch string) CommitEntryOption {
+	return func(c *commitEntryConfig) {
+		c.stackBranch = branch
+	}
+}
+
 // CommitEntry is a value object representing structured commit metadata.
 // It is immutable after construction — all fields are accessed via getters.
 // Construction validates SHA and Message; invalid input returns an error.
 type CommitEntry struct {
-	sha     string
-	message string
-	author  string
-	date    string
+	sha         string
+	message     string
+	author      string
+	date        string
+	stackID     string
+	stackBranch string
 }
 
 // NewCommitEntry constructs a CommitEntry with validation.
@@ -65,10 +83,12 @@ func NewCommitEntry(sha, message string, opts ...CommitEntryOption) (CommitEntry
 	}
 
 	return CommitEntry{
-		sha:     sha,
-		message: message,
-		author:  cfg.author,
-		date:    cfg.date,
+		sha:         sha,
+		message:     message,
+		author:      cfg.author,
+		date:        cfg.date,
+		stackID:     cfg.stackID,
+		stackBranch: cfg.stackBranch,
 	}, nil
 }
 
@@ -101,6 +121,12 @@ func (e CommitEntry) Author() string { return e.author }
 
 // Date returns the commit date in RFC 3339 format (may be empty if not set).
 func (e CommitEntry) Date() string { return e.date }
+
+// StackID returns the merge-base SHA that identifies the stack (may be empty if not set).
+func (e CommitEntry) StackID() string { return e.stackID }
+
+// StackBranch returns the branch name for this stack (may be empty if not set).
+func (e CommitEntry) StackBranch() string { return e.stackBranch }
 
 // String returns a human-readable representation of the CommitEntry.
 func (e CommitEntry) String() string {

--- a/internal/core/domain/commit_entry_test.go
+++ b/internal/core/domain/commit_entry_test.go
@@ -234,6 +234,88 @@ func TestCommitEntry_String_NoAuthorOrDate(t *testing.T) {
 	}
 }
 
+func TestNewCommitEntry_WithStackID(t *testing.T) {
+	t.Parallel()
+
+	validSHA := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	message := "feat: add feature"
+
+	t.Run("WithStackID sets StackID field", func(t *testing.T) {
+		t.Parallel()
+		entry, err := NewCommitEntry(validSHA, message, WithStackID("abc123def456"))
+		if err != nil {
+			t.Fatalf("NewCommitEntry with WithStackID returned unexpected error: %v", err)
+		}
+		if entry.StackID() != "abc123def456" {
+			t.Errorf("entry.StackID() = %q, want %q", entry.StackID(), "abc123def456")
+		}
+	})
+
+	t.Run("WithStackBranch sets StackBranch field", func(t *testing.T) {
+		t.Parallel()
+		entry, err := NewCommitEntry(validSHA, message, WithStackBranch("feature/auth"))
+		if err != nil {
+			t.Fatalf("NewCommitEntry with WithStackBranch returned unexpected error: %v", err)
+		}
+		if entry.StackBranch() != "feature/auth" {
+			t.Errorf("entry.StackBranch() = %q, want %q", entry.StackBranch(), "feature/auth")
+		}
+	})
+
+	t.Run("WithStackID and WithStackBranch together", func(t *testing.T) {
+		t.Parallel()
+		entry, err := NewCommitEntry(validSHA, message, WithStackID("abc123def456"), WithStackBranch("feature/auth"))
+		if err != nil {
+			t.Fatalf("NewCommitEntry with both stack options returned unexpected error: %v", err)
+		}
+		if entry.StackID() != "abc123def456" {
+			t.Errorf("entry.StackID() = %q, want %q", entry.StackID(), "abc123def456")
+		}
+		if entry.StackBranch() != "feature/auth" {
+			t.Errorf("entry.StackBranch() = %q, want %q", entry.StackBranch(), "feature/auth")
+		}
+	})
+
+	t.Run("no stack options yields zero-value StackID and StackBranch", func(t *testing.T) {
+		t.Parallel()
+		entry, err := NewCommitEntry(validSHA, message)
+		if err != nil {
+			t.Fatalf("NewCommitEntry without stack options returned unexpected error: %v", err)
+		}
+		if entry.StackID() != "" {
+			t.Errorf("entry.StackID() = %q, want empty string", entry.StackID())
+		}
+		if entry.StackBranch() != "" {
+			t.Errorf("entry.StackBranch() = %q, want empty string", entry.StackBranch())
+		}
+	})
+
+	t.Run("all options together: Author, Date, StackID, StackBranch", func(t *testing.T) {
+		t.Parallel()
+		entry, err := NewCommitEntry(validSHA, message,
+			WithAuthor("Jane"),
+			WithDate("2026-01-01T00:00:00Z"),
+			WithStackID("mergebaseSHA"),
+			WithStackBranch("develop"),
+		)
+		if err != nil {
+			t.Fatalf("NewCommitEntry with all options returned unexpected error: %v", err)
+		}
+		if entry.Author() != "Jane" {
+			t.Errorf("entry.Author() = %q, want %q", entry.Author(), "Jane")
+		}
+		if entry.Date() != "2026-01-01T00:00:00Z" {
+			t.Errorf("entry.Date() = %q, want %q", entry.Date(), "2026-01-01T00:00:00Z")
+		}
+		if entry.StackID() != "mergebaseSHA" {
+			t.Errorf("entry.StackID() = %q, want %q", entry.StackID(), "mergebaseSHA")
+		}
+		if entry.StackBranch() != "develop" {
+			t.Errorf("entry.StackBranch() = %q, want %q", entry.StackBranch(), "develop")
+		}
+	})
+}
+
 func TestMessages(t *testing.T) {
 	t.Parallel()
 

--- a/internal/delivery/mcp/core/commit_handler.go
+++ b/internal/delivery/mcp/core/commit_handler.go
@@ -251,6 +251,8 @@ func (h *Handler) handlePreview(ctx context.Context, params map[string]any, why 
 		var logOutput string
 		logErr := error(nil)
 		skipReconcile := false
+		var stackID string     // merge-base SHA for stack grouping
+		var stackBranch string // current branch name for stack grouping
 		if currentBranch != "" {
 			projectCfg := h.loadProjectConfig()
 			baseBranch := projectCfg.BaseBranch
@@ -266,6 +268,9 @@ func (h *Handler) handlePreview(ctx context.Context, params map[string]any, why 
 				if mbErr == nil && mergeBase != "" {
 					logOutput, logErr = h.git.LogRange(mergeBase, "HEAD")
 					resolved = true
+					// Stack metadata: group by merge-base and current branch
+					stackID = mergeBase
+					stackBranch = currentBranch
 				}
 				// If MergeBase fails, fall back to full log (not hardcoded list)
 			}
@@ -307,7 +312,17 @@ func (h *Handler) handlePreview(ctx context.Context, params map[string]any, why 
 					if len(parts) < 4 {
 						continue
 					}
-					entry, err := domain.NewCommitEntry(parts[0], parts[3], domain.WithAuthor(parts[1]), domain.WithDate(parts[2]))
+					opts := []domain.CommitEntryOption{
+						domain.WithAuthor(parts[1]),
+						domain.WithDate(parts[2]),
+					}
+					if stackID != "" {
+						opts = append(opts, domain.WithStackID(stackID))
+					}
+					if stackBranch != "" {
+						opts = append(opts, domain.WithStackBranch(stackBranch))
+					}
+					entry, err := domain.NewCommitEntry(parts[0], parts[3], opts...)
 					if err != nil {
 						log.Printf("[WARN] Failed to parse commit entry from log: %v", err)
 						continue

--- a/internal/delivery/mcp/core/handler_test.go
+++ b/internal/delivery/mcp/core/handler_test.go
@@ -1851,7 +1851,7 @@ func TestHandlePreview_BaseBranchConfigured_UsesMergeBase(t *testing.T) {
 
 	mStore := new(mockCommitStore)
 	mStore.On("SetBranch", "feature/auth").Return(nil)
-	expectedEntry, _ := domain.NewCommitEntry("abc123def4560000000000000000000000000001", "feat: add auth", domain.WithAuthor("Alice"), domain.WithDate("2026-06-01"))
+	expectedEntry, _ := domain.NewCommitEntry("abc123def4560000000000000000000000000001", "feat: add auth", domain.WithAuthor("Alice"), domain.WithDate("2026-06-01"), domain.WithStackID("abc123def456"), domain.WithStackBranch("feature/auth"))
 	mStore.On("Reconcile", []domain.CommitEntry{expectedEntry}).Return(nil)
 
 	mLLM := new(mockLLM)
@@ -2094,6 +2094,143 @@ func TestMockGit_MergeBaseAndLogRange(t *testing.T) {
 	assert.Equal(t, "log error", err4.Error())
 
 	m.AssertExpectations(t)
+}
+
+func TestHandlePreview_StackMetadataInjected_WithBaseBranch(t *testing.T) {
+	// When BaseBranch is configured and current branch differs,
+	// entries passed to Reconcile should have StackID and StackBranch set.
+	// StackID = merge-base SHA, StackBranch = current branch name.
+	mGit := new(mockGit)
+	mGit.On("CurrentBranch").Return("feature/auth", nil)
+	mGit.On("MergeBase", "develop", "feature/auth").Return("abc123def456789012345678901234567890ab", nil)
+	mGit.On("LogRange", "abc123def456789012345678901234567890ab", "HEAD").Return("abc123def4560000000000000000000000000001|Alice|2026-06-01|feat: add auth\nabc123def4560000000000000000000000000002|Bob|2026-06-02|fix: bug", nil)
+	mGit.On("Add", []string{domain.MetadataDir}).Return(nil)
+	mGit.On("WriteTree").Return("tree123", nil)
+	mGit.On("Head").Return("abc123def4560000000000000000000000000001", nil)
+	mGit.On("Reset", "HEAD", domain.MetadataDir).Return("reset output", nil)
+	mGit.On("Status").Return(domain.Status{Branch: "feature/auth", IsClean: false, Modified: 1, Files: []domain.FileStatus{{Path: "auth.go", Status: "M ", Staged: true}}}, nil)
+	mGit.On("DiffStaged", mock.Anything).Return("diff --git a/auth.go b/auth.go\n+added line", nil)
+
+	mStore := new(mockCommitStore)
+	mStore.On("SetBranch", "feature/auth").Return(nil)
+
+	// Verify entries have StackID and StackBranch set correctly
+	mStore.On("Reconcile", mock.MatchedBy(func(entries []domain.CommitEntry) bool {
+		if len(entries) != 2 {
+			return false
+		}
+		// Both entries should have the same StackID (merge-base) and StackBranch (current branch)
+		for _, e := range entries {
+			if e.StackID() != "abc123def456789012345678901234567890ab" {
+				return false
+			}
+			if e.StackBranch() != "feature/auth" {
+				return false
+			}
+		}
+		return true
+	})).Return(nil)
+
+	mLLM := new(mockLLM)
+	mLLM.On("GenerateChunkMessage", mock.Anything).Return("feat: test commit", nil)
+	mLLM.On("ClassifyBinary", mock.Anything).Return("feat", nil)
+
+	mChunker := new(mockDiffChunker)
+	mChunker.On("Chunk", mock.Anything, mock.Anything).Return([]domain.DiffChunk{{Files: []string{"auth.go"}, Diff: "test diff"}}, nil)
+
+	mSecurity := new(mockSecurityService)
+	mSecurity.On("CheckFiles", mock.Anything, mock.Anything).Return(&ports.SecurityCheckResult{Blocked: false})
+
+	commitSvc := workflow.NewCommitService(
+		mGit, mLLM, mChunker, mSecurity,
+		workflow.DefaultCommitServiceConfig(4096, 50, t.TempDir()+"/task.log"),
+		mStore,
+	)
+
+	confirm := confirm.NewInMemory(5 * time.Minute)
+	cfg := config.Default()
+	rev := workflow.New(mGit, mLLM, confirm, cfg, commitSvc, nil, mSecurity)
+
+	h := NewHandler(mGit, commitSvc, rev, mLLM, "", nil, nil)
+	h.configProvider = func() *domain.ProjectConfig {
+		return &domain.ProjectConfig{BaseBranch: "develop", Areas: map[string][]string{}}
+	}
+
+	args := map[string]any{"command": "PREVIEW", "why": "test"}
+	req := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: args}}
+
+	res, err := h.HandleCommit(context.Background(), req)
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+
+	mGit.AssertCalled(t, "MergeBase", "develop", "feature/auth")
+	mStore.AssertExpectations(t)
+}
+
+func TestHandlePreview_StackMetadataEmpty_WhenBaseBranchEmpty(t *testing.T) {
+	// When BaseBranch is empty, entries should have empty StackID and StackBranch.
+	// This tests the fallback path (hardcoded list).
+	mGit := new(mockGit)
+	mGit.On("CurrentBranch").Return("feature/test", nil)
+	mGit.On("MergeBase", "main", "feature/test").Return("abc123000000000000000000000000000000000", nil)
+	mGit.On("LogRange", "abc123000000000000000000000000000000000", "HEAD").Return("abc1230000000000000000000000000000000001|Alice|2026-06-01|feat: test", nil)
+	mGit.On("Add", []string{domain.MetadataDir}).Return(nil)
+	mGit.On("WriteTree").Return("tree123", nil)
+	mGit.On("Head").Return("abc1230000000000000000000000000000000001", nil)
+	mGit.On("Reset", "HEAD", domain.MetadataDir).Return("reset output", nil)
+	mGit.On("Status").Return(domain.Status{Branch: "feature/test", IsClean: false, Modified: 1, Files: []domain.FileStatus{{Path: "test.go", Status: "M ", Staged: true}}}, nil)
+	mGit.On("DiffStaged", mock.Anything).Return("diff --git a/test.go b/test.go\n+added line", nil)
+
+	mStore := new(mockCommitStore)
+	mStore.On("SetBranch", "feature/test").Return(nil)
+
+	// Verify entries have empty StackID and StackBranch (no BaseBranch configured)
+	mStore.On("Reconcile", mock.MatchedBy(func(entries []domain.CommitEntry) bool {
+		for _, e := range entries {
+			if e.StackID() != "" {
+				return false
+			}
+			if e.StackBranch() != "" {
+				return false
+			}
+		}
+		return true
+	})).Return(nil)
+
+	mLLM := new(mockLLM)
+	mLLM.On("GenerateChunkMessage", mock.Anything).Return("feat: test commit", nil)
+	mLLM.On("ClassifyBinary", mock.Anything).Return("feat", nil)
+
+	mChunker := new(mockDiffChunker)
+	mChunker.On("Chunk", mock.Anything, mock.Anything).Return([]domain.DiffChunk{{Files: []string{"test.go"}, Diff: "test diff"}}, nil)
+
+	mSecurity := new(mockSecurityService)
+	mSecurity.On("CheckFiles", mock.Anything, mock.Anything).Return(&ports.SecurityCheckResult{Blocked: false})
+
+	commitSvc := workflow.NewCommitService(
+		mGit, mLLM, mChunker, mSecurity,
+		workflow.DefaultCommitServiceConfig(4096, 50, t.TempDir()+"/task.log"),
+		mStore,
+	)
+
+	confirm := confirm.NewInMemory(5 * time.Minute)
+	cfg := config.Default()
+	rev := workflow.New(mGit, mLLM, confirm, cfg, commitSvc, nil, mSecurity)
+
+	h := NewHandler(mGit, commitSvc, rev, mLLM, "", nil, nil)
+	// Empty BaseBranch — no stack metadata should be injected
+	h.configProvider = func() *domain.ProjectConfig {
+		return &domain.ProjectConfig{Areas: map[string][]string{}}
+	}
+
+	args := map[string]any{"command": "PREVIEW", "why": "test"}
+	req := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: args}}
+
+	res, err := h.HandleCommit(context.Background(), req)
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+
+	mStore.AssertExpectations(t)
 }
 
 func TestHandlePreview_UnstageMetadataTriangulation_HeadErrorAndResetError(t *testing.T) {


### PR DESCRIPTION
## Summary

Phase 2 of stacks v2.2 — extends `CommitEntry` with `stackID` and `stackBranch` fields, updates serialization, and injects stack metadata in the commit handler before reconciliation.

## Changes

- **`domain/commit_entry.go`**: Added `stackID`/`stackBranch` private fields, `WithStackID()`/`WithStackBranch()` functional options, `StackID()`/`StackBranch()` getters
- **`commitstore/adapter.go`**: Added `StackID`/`StackBranch` to `jsonEntry` with `omitempty`; updated `write()`, `readLocked()`, `entriesEqual()`, `Append()`, `ReadAllBranches()` for stack fields
- **`commit_handler.go`**: Inject `WithStackID(mergeBase)` and `WithStackBranch(currentBranch)` before `store.Reconcile()`; empty strings when `BaseBranch` is empty
- **11 new tests**: CommitEntry construction (5), jsonEntry round-trip (4), handler stack injection (2)

## Test Results

All tests pass.

## Depends On

- #114 (Phase 1: Reconciler fix + BaseBranch config)