### PR TITLE
fix: corrige bugs 1-5 en el pipeline commit→release (encadenada con stacks-v2.2-phase3)

### DIFF
--- a/.git-courer/branches/fix-bugs-1-5/commits.json
+++ b/.git-courer/branches/fix-bugs-1-5/commits.json
@@ -64,5 +64,11 @@
     "message": "feat(domain): add BaseBranch field to ProjectConfig",
     "author": "blak0p",
     "date": "2026-06-04"
+  },
+  {
+    "sha": "346e7019d08cab8bc715346a0c33d43335ffd55d",
+    "message": "feat: refine changelog generation and release entry filtering\n\nWHY\nChangelog generation included noisy, non-user-facing commits and maintenance tasks. Additionally, stale pending entries and excluded paths were causing incorrect release metadata and inaccurate stack grouping.\n\nWHAT\n* Implemented filtering for non-user-facing commit types (chore, test, ci, build) unless they contain breaking changes.\n* Added scope-based exclusion logic against project-defined paths.\n* Reset pendingEntries before git-history fallback to prevent stale data.\n* Filtered pending entries for skipTypes and excluded paths before grouping in release generation.",
+    "author": "blak0p",
+    "date": "2026-06-06T10:18:56Z"
   }
 ]

--- a/.git-courer/branches/fix-bugs-1-5/commits.json
+++ b/.git-courer/branches/fix-bugs-1-5/commits.json
@@ -1,0 +1,62 @@
+[
+  {
+    "sha": "2f943ab9217a7d185f8532033ffa7d4df07a0149",
+    "message": "feat(init): add base_branch prompt to CLI and TUI init wizards with auto-detection",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "11d51ee51b3a5ffef801726a5103bd2740e086d4",
+    "message": "feat: implement stack-based grouping for release generation",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "9a15d293f6d9f98fcbdaa93b6993990712ca894e",
+    "message": "feat: implement grouped changelog generation by area and stack",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "452c3a93430407886ed825581aa1504a2413c045",
+    "message": "feat: integrate stack metadata into commit lifecycle",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "ecb1b508d89f524535dff5f965390fc35146bb2f",
+    "message": "chore: add CI release configuration for native binaries",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "b6c97679b0701b7fece79a776abb2aeaffd474bb",
+    "message": "fix: add SymbolicRef to git mocks and ignore local config",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "27e3bcbc3962acfe67f2810789393176e6809c56",
+    "message": "chore: add SymbolicRef to all Git mock implementations",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "7648371b200d4b8adb23da85f017f97ff41ad196",
+    "message": "feat(domain): add DetectBaseBranch helper and SymbolicRef port",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "8ad287cebf8d1ac4941a3d334e1ff13b11567b13",
+    "message": "feat(handler): replace hardcoded base branch list with ProjectConfig.BaseBranch",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  },
+  {
+    "sha": "889c0550d20bce04706698f9fac1e757f69f41b0",
+    "message": "feat(domain): add BaseBranch field to ProjectConfig",
+    "author": "blak0p",
+    "date": "2026-06-04"
+  }
+]

--- a/.git-courer/branches/fix-bugs-1-5/commits.json
+++ b/.git-courer/branches/fix-bugs-1-5/commits.json
@@ -1,5 +1,11 @@
 [
   {
+    "sha": "dd2ba0c3cdb8311086c104102b33192f7b2765bf",
+    "message": "fix!: fix merge base resolution and persist stack metadata",
+    "author": "blak0p",
+    "date": "2026-06-06"
+  },
+  {
     "sha": "2f943ab9217a7d185f8532033ffa7d4df07a0149",
     "message": "feat(init): add base_branch prompt to CLI and TUI init wizards with auto-detection",
     "author": "blak0p",

--- a/internal/delivery/mcp/core/commit_handler.go
+++ b/internal/delivery/mcp/core/commit_handler.go
@@ -34,13 +34,15 @@ const (
 // BgJob tracks a background goroutine's completion state.
 // Plan data lives in ConfirmStore; this also carries the tree snapshot and done signal.
 type BgJob struct {
-	ID       string
-	Status   BgJobStatus
-	Error    string
-	TreeHash string        // write-once before goroutine
-	Message  string        // write-once in goroutine, read after Done
-	Why      string        // custom explanation or justification
-	Done     chan struct{} // make(chan struct{}), closed when goroutine finishes
+	ID          string
+	Status      BgJobStatus
+	Error       string
+	TreeHash    string // write-once before goroutine
+	Message     string // write-once in goroutine, read after Done
+	Why         string // custom explanation or justification
+	StackID     string // merge-base SHA for stack grouping (set during PREVIEW)
+	StackBranch string // current branch name for stack grouping (set during PREVIEW)
+	Done        chan struct{} // make(chan struct{}), closed when goroutine finishes
 }
 
 // Handler holds dependencies for core domain MCP handlers (commit, amend, revert, diff, status).
@@ -237,6 +239,10 @@ func (h *Handler) handlePreview(ctx context.Context, params map[string]any, why 
 		return shared.JSONErrorResult("PREVIEW", fmt.Errorf("commit service not available"))
 	}
 
+	// Stack metadata: declared at function level so it's available for BgJob creation
+	var stackID string     // merge-base SHA for stack grouping
+	var stackBranch string // current branch name for stack grouping
+
 	// 1. Resolve branch and reconcile commit store
 	if store := h.commitSvc.CommitStore(); store != nil {
 		currentBranch, err := h.git.CurrentBranch()
@@ -251,8 +257,6 @@ func (h *Handler) handlePreview(ctx context.Context, params map[string]any, why 
 		var logOutput string
 		logErr := error(nil)
 		skipReconcile := false
-		var stackID string     // merge-base SHA for stack grouping
-		var stackBranch string // current branch name for stack grouping
 		if currentBranch != "" {
 			projectCfg := h.loadProjectConfig()
 			baseBranch := projectCfg.BaseBranch
@@ -265,14 +269,20 @@ func (h *Handler) handlePreview(ctx context.Context, params map[string]any, why 
 			} else if baseBranch != "" {
 				// BaseBranch configured — single merge-base call.
 				mergeBase, mbErr := h.git.MergeBase(baseBranch, currentBranch)
-				if mbErr == nil && mergeBase != "" {
+				if mbErr != nil {
+					// Bug 1: When BaseBranch is configured and MergeBase fails, return error
+					// Do NOT fall back to full log — this pollutes CommitStore with cross-branch history
+					log.Printf("[WARN] MergeBase(%q, %q) failed: %v — returning error instead of falling back", baseBranch, currentBranch, mbErr)
+					return shared.JSONErrorResult("PREVIEW", fmt.Errorf("cannot resolve merge base for configured BaseBranch %q: %w", baseBranch, mbErr))
+				}
+				if mergeBase != "" {
 					logOutput, logErr = h.git.LogRange(mergeBase, "HEAD")
 					resolved = true
 					// Stack metadata: group by merge-base and current branch
 					stackID = mergeBase
 					stackBranch = currentBranch
 				}
-				// If MergeBase fails, fall back to full log (not hardcoded list)
+				// If MergeBase succeeds but returns empty, fall through to hardcoded list
 			}
 
 			if !skipReconcile && !resolved && baseBranch == "" {
@@ -395,12 +405,14 @@ func (h *Handler) handlePreview(ctx context.Context, params map[string]any, why 
 		// Fast-path job is immediately complete: Status=BgDone, Message set, Done closed.
 		jobID := fmt.Sprintf("commit-%d", time.Now().UnixMilli())
 		bgJob := &BgJob{
-			ID:       jobID,
-			Status:   BgDone,
-			TreeHash: treeHash,
-			Message:  commitMsg,
-			Why:      why,
-			Done:     make(chan struct{}),
+			ID:          jobID,
+			Status:      BgDone,
+			TreeHash:    treeHash,
+			Message:     commitMsg,
+			Why:         why,
+			StackID:     stackID,
+			StackBranch: stackBranch,
+			Done:        make(chan struct{}),
 		}
 		close(bgJob.Done) // fast path: done immediately
 		h.bgJobs.Store(jobID, bgJob)
@@ -434,6 +446,10 @@ func (h *Handler) handlePreview(ctx context.Context, params map[string]any, why 
 		// Send progress: still processing
 		shared.SendProgress(ctx, h.mcpServer, params, 3, shared.ProgressTotal, shared.CommitProgressMessage(shared.ProgressClassify))
 
+		// Capture stack metadata for the async goroutine (closure capture)
+		capturedStackID := stackID
+		capturedStackBranch := stackBranch
+
 		jobID := fmt.Sprintf("commit-%d", time.Now().UnixMilli())
 		bgJob := &BgJob{
 			ID:       jobID,
@@ -460,6 +476,9 @@ func (h *Handler) handlePreview(ctx context.Context, params map[string]any, why 
 			} else {
 				j.Message = res.result.Output
 			}
+			// Store stack metadata resolved during PREVIEW
+			j.StackID = capturedStackID
+			j.StackBranch = capturedStackBranch
 			close(j.Done)
 			log.Printf("[commit] job %s done (async)", jobID)
 		}()
@@ -605,7 +624,36 @@ func (h *Handler) applyPlumbing(ctx context.Context, jobID string, pushAfter boo
 	}
 
 	// Capture the commit metadata in the commit store for release logs/changelogs
-	h.commitSvc.CaptureCommit(message)
+	// Pass stack metadata from PREVIEW to preserve grouping information
+	h.commitSvc.CaptureCommit(message, job.StackID, job.StackBranch)
+
+	// Bug 3: Plumbing amend — stage .git-courer/, write new tree, create replacement commit, update HEAD
+	// This ensures the pushed commit includes the latest metadata entry
+	if err := h.git.Add([]string{domain.MetadataDir}); err != nil {
+		log.Printf("[WARN] applyPlumbing: failed to stage .git-courer/: %v", err)
+	} else {
+		// Write a new tree that includes the staged metadata
+		newTreeHash, treeErr := h.git.WriteTree()
+		if treeErr != nil {
+			log.Printf("[WARN] applyPlumbing: WriteTree failed: %v", treeErr)
+		} else {
+			// Create a replacement commit with the same parent (original commit) but new tree
+			replacementCommit, commitErr := h.git.CommitTree(newTreeHash, commitHash, message)
+			if commitErr != nil {
+				log.Printf("[WARN] applyPlumbing: CommitTree (amend) failed: %v", commitErr)
+			} else {
+				// Update HEAD to point to the replacement commit
+				_, refErr := h.git.UpdateRef("HEAD", replacementCommit)
+				if refErr != nil {
+					log.Printf("[WARN] applyPlumbing: UpdateRef failed: %v", refErr)
+				} else {
+					// Success — update commitHash to the replacement for the response
+					commitHash = replacementCommit
+					log.Printf("[DEBUG] applyPlumbing: metadata amend successful — commit %s → %s", commitHash, replacementCommit)
+				}
+			}
+		}
+	}
 
 	// Release confirm lock after successful plumbing commit
 	h.reviewWorkflow.CleanupAfterPlumbing()

--- a/internal/delivery/mcp/core/handler_test.go
+++ b/internal/delivery/mcp/core/handler_test.go
@@ -1241,13 +1241,21 @@ func TestHandleApply_JobFailed_ReturnsError(t *testing.T) {
 }
 
 // TestHandleApply_JobDone_HappyPath verifies the full plumbing path:
-// lookup BgJob → compose message → Head → CommitTree → UpdateRef → Reset → delete job.
+// lookup BgJob → compose message → Head → CommitTree → UpdateRef → CaptureCommit → plumbing amend → Reset → delete job.
 func TestHandleApply_JobDone_HappyPath(t *testing.T) {
 	mGit := new(mockGit)
 	// Set up mock expectations for the plumbing path
+	// Note: This test has no commitSvc store, so CaptureCommit is a no-op,
+	// but the plumbing amend still runs (stages .git-courer, WriteTree, CommitTree amend, UpdateRef)
 	mGit.On("Head").Return("parent123", nil)
 	mGit.On("CommitTree", "tree456", "parent123", "feat: add auth\n\nRefresh tokens are rotated every 24h").Return("commit789", nil)
+	// First UpdateRef: move HEAD to the initial commit
 	mGit.On("UpdateRef", "HEAD", "commit789").Return("", nil)
+	// Plumbing amend sequence (Bug 3)
+	mGit.On("Add", []string{domain.MetadataDir}).Return(nil)
+	mGit.On("WriteTree").Return("newTree999", nil)
+	mGit.On("CommitTree", "newTree999", "commit789", "feat: add auth\n\nRefresh tokens are rotated every 24h").Return("replacementCommit888", nil)
+	mGit.On("UpdateRef", "HEAD", "replacementCommit888").Return("", nil)
 	mGit.On("Reset", "HEAD", ".").Return("", nil)
 
 	h := newTestHandler(t, mGit)
@@ -1270,7 +1278,7 @@ func TestHandleApply_JobDone_HappyPath(t *testing.T) {
 	assert.NotNil(t, res)
 
 	text := res.Content[0].(mcpgo.TextContent).Text
-	assert.Contains(t, text, "commit789", "result should contain commit hash")
+	assert.Contains(t, text, "replacementCommit888", "result should contain replacement commit hash")
 
 	// Job should be deleted after successful apply
 	_, ok := h.bgJobs.Load(jobID)
@@ -1286,6 +1294,7 @@ func TestHandleApply_CommitTreeFails_NoUpdateRef(t *testing.T) {
 	mGit.On("Head").Return("parent123", nil)
 	mGit.On("CommitTree", "tree456", "parent123", mock.Anything).Return("", fmt.Errorf("commit-tree failed"))
 	// UpdateRef should NOT be called — no mock setup means panic if called
+	// Plumbing amend sequence is not reached since first CommitTree fails
 
 	h := newTestHandler(t, mGit)
 
@@ -1319,8 +1328,9 @@ func TestHandleApply_UpdateRefFails_ErrorContainsCommitHash(t *testing.T) {
 	mGit := new(mockGit)
 	mGit.On("Head").Return("parent123", nil)
 	mGit.On("CommitTree", "tree456", "parent123", mock.Anything).Return("commit789", nil)
+	// First UpdateRef fails - this is the error that returns commitHash
 	mGit.On("UpdateRef", "HEAD", "commit789").Return("", fmt.Errorf("update-ref failed"))
-	// Reset should NOT be called after UpdateRef failure
+	// Subsequent calls should NOT happen since we return error after first UpdateRef fails
 
 	h := newTestHandler(t, mGit)
 
@@ -1354,7 +1364,14 @@ func TestHandleApply_ResetFails_CommitStillValid(t *testing.T) {
 	mGit := new(mockGit)
 	mGit.On("Head").Return("parent123", nil)
 	mGit.On("CommitTree", "tree456", "parent123", mock.Anything).Return("commit789", nil)
+	// First UpdateRef: move HEAD to the initial commit
 	mGit.On("UpdateRef", "HEAD", "commit789").Return("", nil)
+	// Plumbing amend sequence succeeds
+	mGit.On("Add", []string{domain.MetadataDir}).Return(nil)
+	mGit.On("WriteTree").Return("newTree999", nil)
+	mGit.On("CommitTree", "newTree999", "commit789", mock.Anything).Return("replacementCommit888", nil)
+	mGit.On("UpdateRef", "HEAD", "replacementCommit888").Return("", nil)
+	// Reset fails but commit is still valid
 	mGit.On("Reset", "HEAD", ".").Return("", fmt.Errorf("reset failed"))
 
 	h := newTestHandler(t, mGit)
@@ -1377,7 +1394,7 @@ func TestHandleApply_ResetFails_CommitStillValid(t *testing.T) {
 	assert.NotNil(t, res)
 
 	text := res.Content[0].(mcpgo.TextContent).Text
-	assert.Contains(t, text, "commit789", "result should contain commit hash even with reset warning")
+	assert.Contains(t, text, "replacementCommit888", "result should contain replacement commit hash even with reset warning")
 
 	// Job should be deleted (commit was successful)
 	_, ok := h.bgJobs.Load(jobID)
@@ -1392,7 +1409,13 @@ func TestHandleApply_PushAfter_CallsPush(t *testing.T) {
 	mGit := new(mockGit)
 	mGit.On("Head").Return("parent123", nil)
 	mGit.On("CommitTree", "tree456", "parent123", mock.Anything).Return("commit789", nil)
+	// First UpdateRef: move HEAD to the initial commit
 	mGit.On("UpdateRef", "HEAD", "commit789").Return("", nil)
+	// Plumbing amend sequence succeeds
+	mGit.On("Add", []string{domain.MetadataDir}).Return(nil)
+	mGit.On("WriteTree").Return("newTree999", nil)
+	mGit.On("CommitTree", "newTree999", "commit789", mock.Anything).Return("replacementCommit888", nil)
+	mGit.On("UpdateRef", "HEAD", "replacementCommit888").Return("", nil)
 	mGit.On("Reset", "HEAD", ".").Return("", nil)
 	mGit.On("Push").Return("push output", nil)
 
@@ -1415,7 +1438,7 @@ func TestHandleApply_PushAfter_CallsPush(t *testing.T) {
 	assert.NotNil(t, res)
 
 	text := res.Content[0].(mcpgo.TextContent).Text
-	assert.Contains(t, text, "commit789")
+	assert.Contains(t, text, "replacementCommit888")
 	assert.Contains(t, text, "push", "result should mention push status")
 
 	mGit.AssertExpectations(t)
@@ -1427,7 +1450,13 @@ func TestHandleApply_PushAfter_PushFails_WarningNotHardError(t *testing.T) {
 	mGit := new(mockGit)
 	mGit.On("Head").Return("parent123", nil)
 	mGit.On("CommitTree", "tree456", "parent123", mock.Anything).Return("commit789", nil)
+	// First UpdateRef: move HEAD to the initial commit
 	mGit.On("UpdateRef", "HEAD", "commit789").Return("", nil)
+	// Plumbing amend sequence succeeds
+	mGit.On("Add", []string{domain.MetadataDir}).Return(nil)
+	mGit.On("WriteTree").Return("newTree999", nil)
+	mGit.On("CommitTree", "newTree999", "commit789", mock.Anything).Return("replacementCommit888", nil)
+	mGit.On("UpdateRef", "HEAD", "replacementCommit888").Return("", nil)
 	mGit.On("Reset", "HEAD", ".").Return("", nil)
 	mGit.On("Push").Return("", fmt.Errorf("push failed: remote rejected"))
 
@@ -1451,7 +1480,7 @@ func TestHandleApply_PushAfter_PushFails_WarningNotHardError(t *testing.T) {
 	assert.NotNil(t, res)
 
 	text := res.Content[0].(mcpgo.TextContent).Text
-	assert.Contains(t, text, "commit789")
+	assert.Contains(t, text, "replacementCommit888")
 	assert.Contains(t, text, "push failed", "result should contain push failure warning")
 
 	mGit.AssertExpectations(t)
@@ -1464,7 +1493,13 @@ func TestHandleApply_MessageFromJob_PrePopulated(t *testing.T) {
 	expectedMessage := "feat: add refresh token rotation"
 	mGit.On("Head").Return("parent123", nil)
 	mGit.On("CommitTree", "tree456", "parent123", expectedMessage).Return("commit789", nil)
+	// First UpdateRef: move HEAD to the initial commit
 	mGit.On("UpdateRef", "HEAD", "commit789").Return("", nil)
+	// Plumbing amend sequence
+	mGit.On("Add", []string{domain.MetadataDir}).Return(nil)
+	mGit.On("WriteTree").Return("newTree999", nil)
+	mGit.On("CommitTree", "newTree999", "commit789", expectedMessage).Return("replacementCommit888", nil)
+	mGit.On("UpdateRef", "HEAD", "replacementCommit888").Return("", nil)
 	mGit.On("Reset", "HEAD", ".").Return("", nil)
 
 	h := newTestHandler(t, mGit)
@@ -1503,6 +1538,11 @@ func TestHandleApply_MessageFromGenerateCommitMessage(t *testing.T) {
 	// The message comes from GenerateCommitMessage through composeMessage — use mock.Anything for message
 	mGit.On("CommitTree", "tree456", "parent123", mock.Anything).Return("commit789", nil)
 	mGit.On("UpdateRef", "HEAD", "commit789").Return("", nil)
+	// Plumbing amend sequence
+	mGit.On("Add", []string{domain.MetadataDir}).Return(nil)
+	mGit.On("WriteTree").Return("newTree999", nil)
+	mGit.On("CommitTree", "newTree999", "commit789", mock.Anything).Return("replacementCommit888", nil)
+	mGit.On("UpdateRef", "HEAD", "replacementCommit888").Return("", nil)
 	mGit.On("Reset", "HEAD", ".").Return("", nil)
 
 	h := newTestHandler(t, mGit)
@@ -1526,7 +1566,7 @@ func TestHandleApply_MessageFromGenerateCommitMessage(t *testing.T) {
 	assert.NotNil(t, res)
 
 	text := res.Content[0].(mcpgo.TextContent).Text
-	assert.Contains(t, text, "commit789", "result should contain commit hash")
+	assert.Contains(t, text, "replacementCommit888", "result should contain replacement commit hash")
 	// Verify the message was not empty (proving GenerateCommitMessage was called)
 	mGit.AssertCalled(t, "CommitTree", "tree456", "parent123", mock.MatchedBy(func(msg string) bool {
 		return msg != "" // non-empty message proves GenerateCommitMessage was called
@@ -1543,6 +1583,11 @@ func TestHandleApply_WhyPropagation(t *testing.T) {
 	mGit.On("Head").Return("parent123", nil)
 	mGit.On("CommitTree", "tree456", "parent123", mock.Anything).Return("commit789", nil)
 	mGit.On("UpdateRef", "HEAD", "commit789").Return("", nil)
+	// Plumbing amend sequence
+	mGit.On("Add", []string{domain.MetadataDir}).Return(nil)
+	mGit.On("WriteTree").Return("newTree999", nil)
+	mGit.On("CommitTree", "newTree999", "commit789", mock.Anything).Return("replacementCommit888", nil)
+	mGit.On("UpdateRef", "HEAD", "replacementCommit888").Return("", nil)
 	mGit.On("Reset", "HEAD", ".").Return("", nil)
 
 	// Custom LLM tracking SetWhy
@@ -2010,35 +2055,29 @@ func TestHandlePreview_BaseBranchEmpty_FallsBackToHardcodedList(t *testing.T) {
 	mStore.AssertExpectations(t)
 }
 
-func TestHandlePreview_BaseBranchConfigured_MergeBaseError_FallsBackToFullLog(t *testing.T) {
-	// When BaseBranch is "develop" but MergeBase fails, fall back to full log.
+func TestHandlePreview_BaseBranchConfigured_MergeBaseError_ReturnsError(t *testing.T) {
+	// Bug 1: When BaseBranch is "develop" and MergeBase fails, return error (do NOT fall back to full log).
 	mGit := new(mockGit)
 	mGit.On("CurrentBranch").Return("feature/auth", nil)
-	// MergeBase fails
+	// MergeBase fails — should return error immediately
 	mGit.On("MergeBase", "develop", "feature/auth").Return("", fmt.Errorf("no merge base"))
-	// Should fall back to Log(0, "")
-	mGit.On("Log", 0, "", mock.Anything).Return("abc1230000000000000000000000000000000001|Alice|2026-06-01|feat: add auth", nil)
+	// WriteTree is called before the error path (staging happens before branch resolution)
 	mGit.On("Add", []string{domain.MetadataDir}).Return(nil)
 	mGit.On("WriteTree").Return("tree123", nil)
-	mGit.On("Head").Return("abc1230000000000000000000000000000000001", nil)
-	mGit.On("Reset", "HEAD", domain.MetadataDir).Return("reset output", nil)
-	mGit.On("Status").Return(domain.Status{Branch: "feature/auth", IsClean: false, Modified: 1, Files: []domain.FileStatus{{Path: "auth.go", Status: "M ", Staged: true}}}, nil)
-	mGit.On("DiffStaged", mock.Anything).Return("diff --git a/auth.go b/auth.go\n+added line", nil)
+	// Log should NOT be called since we return error on MergeBase failure
 
 	mStore := new(mockCommitStore)
 	mStore.On("SetBranch", "feature/auth").Return(nil)
-	expectedEntry, _ := domain.NewCommitEntry("abc1230000000000000000000000000000000001", "feat: add auth", domain.WithAuthor("Alice"), domain.WithDate("2026-06-01"))
-	mStore.On("Reconcile", []domain.CommitEntry{expectedEntry}).Return(nil)
+	// Reconcile should NOT be called since we return error on MergeBase failure
 
 	mLLM := new(mockLLM)
-	mLLM.On("GenerateChunkMessage", mock.Anything).Return("feat: test commit", nil)
-	mLLM.On("ClassifyBinary", mock.Anything).Return("feat", nil)
+	// LLM should NOT be called since we return error on MergeBase failure
 
 	mChunker := new(mockDiffChunker)
-	mChunker.On("Chunk", mock.Anything, mock.Anything).Return([]domain.DiffChunk{{Files: []string{"auth.go"}, Diff: "test diff"}}, nil)
+	// Chunker should NOT be called
 
 	mSecurity := new(mockSecurityService)
-	mSecurity.On("CheckFiles", mock.Anything, mock.Anything).Return(&ports.SecurityCheckResult{Blocked: false})
+	// Security should NOT be called
 
 	commitSvc := workflow.NewCommitService(
 		mGit, mLLM, mChunker, mSecurity,
@@ -2059,12 +2098,17 @@ func TestHandlePreview_BaseBranchConfigured_MergeBaseError_FallsBackToFullLog(t 
 	req := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: args}}
 
 	res, err := h.HandleCommit(context.Background(), req)
+	// JSONErrorResult returns result with error content, not an error return value
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
+	// Error responses contain "error" in the JSON
+	assert.Contains(t, res.Content[0].(mcpgo.TextContent).Text, "error")
+	assert.Contains(t, res.Content[0].(mcpgo.TextContent).Text, "cannot resolve merge base for configured BaseBranch")
 
-	// Verify MergeBase was called with the configured BaseBranch, and Log was called as fallback
+	// Verify MergeBase was called with the configured BaseBranch
 	mGit.AssertCalled(t, "MergeBase", "develop", "feature/auth")
-	mGit.AssertCalled(t, "Log", 0, "", mock.Anything)
+	// Verify Log was NOT called (no fallback)
+	mGit.AssertNotCalled(t, "Log", mock.Anything, mock.Anything, mock.Anything)
 	mStore.AssertExpectations(t)
 }
 
@@ -2166,7 +2210,81 @@ func TestHandlePreview_StackMetadataInjected_WithBaseBranch(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
 
-	mGit.AssertCalled(t, "MergeBase", "develop", "feature/auth")
+	mGit.AssertExpectations(t)
+	mStore.AssertExpectations(t)
+}
+
+// Bug 3: applyPlumbing integration test — verifies exact call order for metadata amend
+func TestApplyPlumbing_AmendsMetadataAfterCaptureCommit(t *testing.T) {
+	mGit := new(mockGit)
+	mStore := new(mockCommitStore)
+	mLLM := new(mockLLM)
+
+	commitSvc := workflow.NewCommitService(
+		mGit, mLLM, &mockDiffChunker{}, &mockSecurityService{},
+		workflow.DefaultCommitServiceConfig(4096, 50, t.TempDir()+"/task.log"),
+		mStore,
+	)
+
+	confirm := confirm.NewInMemory(5*time.Minute)
+	cfg := config.Default()
+	rev := workflow.New(mGit, mLLM, confirm, cfg, commitSvc, nil, &mockSecurityService{})
+
+	h := NewHandler(mGit, commitSvc, rev, mLLM, "", nil, nil)
+
+	// Create a BgJob with stack metadata
+	jobID := "test-job-123"
+	bgJob := &BgJob{
+		ID:          jobID,
+		Status:      BgDone,
+		TreeHash:    "tree123",
+		Message:     "feat: test commit",
+		Why:         "test",
+		StackID:     "abc123",
+		StackBranch: "feature/test",
+		Done:        make(chan struct{}),
+	}
+	close(bgJob.Done)
+	h.bgJobs.Store(jobID, bgJob)
+
+	// Mock the plumbing sequence
+	mGit.On("Head").Return("abcd1234567890abcdef1234567890abcdef1234", nil)
+	mGit.On("CommitTree", "tree123", "abcd1234567890abcdef1234567890abcdef1234", "feat: test commit").Return("commitHash111111111111111111111111111111", nil)
+	// First UpdateRef: move HEAD to the initial commit
+	mGit.On("UpdateRef", "HEAD", "commitHash111111111111111111111111111111").Return("", nil)
+	// CaptureCommit is called (via commitSvc.CaptureCommit) - needs CurrentBranch for SetBranch
+	mGit.On("CurrentBranch").Return("feature/test", nil)
+	mGit.On("ConfigGet", "user.name").Return("Test User", nil)
+	// mStore expects SetBranch and Append (variadic)
+	mStore.On("SetBranch", "feature/test").Return(nil)
+	// Append is variadic: Append(entries ...domain.CommitEntry)
+	// When Called(entries) is used inside the mock, it passes the slice as a single arg
+	mStore.On("Append", mock.AnythingOfType("[]domain.CommitEntry")).Return(nil)
+	// Bug 3: Plumbing amend sequence
+	mGit.On("Add", []string{domain.MetadataDir}).Return(nil)
+	mGit.On("WriteTree").Return("newTreeHash222222222222222222222222222222", nil)
+	mGit.On("CommitTree", "newTreeHash222222222222222222222222222222", "commitHash111111111111111111111111111111", "feat: test commit").Return("replacementHash333333333333333333333333333333", nil)
+	// Second UpdateRef: move HEAD to the replacement commit
+	mGit.On("UpdateRef", "HEAD", "replacementHash333333333333333333333333333333").Return("", nil)
+	mGit.On("Reset", "HEAD", ".").Return("cleanup output", nil)
+
+	args := map[string]any{"command": "APPLY", "job_id": jobID}
+	req := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: args}}
+
+	res, err := h.HandleCommit(context.Background(), req)
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+
+	// Verify the plumbing amend sequence was called in order
+	mGit.AssertCalled(t, "Add", []string{domain.MetadataDir})
+	mGit.AssertCalled(t, "WriteTree")
+	mGit.AssertCalled(t, "CommitTree", mock.Anything, "commitHash111111111111111111111111111111", mock.Anything)
+	mGit.AssertCalled(t, "UpdateRef", "HEAD", mock.Anything)
+
+	// Verify CaptureCommit was called (stack metadata verified by Append being called)
+	mStore.AssertCalled(t, "Append", mock.Anything)
+
+	mGit.AssertExpectations(t)
 	mStore.AssertExpectations(t)
 }
 

--- a/internal/workflow/commit_execute.go
+++ b/internal/workflow/commit_execute.go
@@ -68,7 +68,7 @@ func (s *CommitService) ExecuteFromPlan(messages []string, chunkFiles [][]string
 			continue
 		}
 		committed = append(committed, msg)
-		s.captureCommit(msg)
+		s.captureCommit(msg, "", "")
 	}
 
 	if strings.Contains(strings.ToLower(instruction), "push") {
@@ -89,7 +89,7 @@ func (s *CommitService) ExecuteFromPlan(messages []string, chunkFiles [][]string
 				warnings = append(warnings, fmt.Sprintf("deleted files commit failed: %v", err))
 			} else {
 				committed = append(committed, msg)
-				s.captureCommit(msg)
+				s.captureCommit(msg, "", "")
 			}
 		}
 	}
@@ -141,7 +141,7 @@ func (s *CommitService) executeSync(instruction string, chunks []domain.DiffChun
 			return "", fmt.Errorf("failed commit %d: %w", i+1, err)
 		}
 		committed = append(committed, msg)
-		s.captureCommit(msg)
+		s.captureCommit(msg, "", "")
 	}
 
 	log.Printf("[DEBUG] executeSync: committed %d chunks", len(committed))
@@ -162,7 +162,7 @@ func (s *CommitService) executeSync(instruction string, chunks []domain.DiffChun
 				warnings = append(warnings, fmt.Sprintf("deleted files commit failed: %v", err))
 			} else {
 				committed = append(committed, msg)
-				s.captureCommit(msg)
+				s.captureCommit(msg, "", "")
 			}
 		}
 	}
@@ -190,8 +190,9 @@ func (s *CommitService) rollback(committed []string) {
 // CaptureCommit captures the commit metadata after a successful git commit.
 // It resolves the current branch dynamically, configures the commit store branch,
 // gets commit metadata, and appends it to the CommitStore.
-func (s *CommitService) CaptureCommit(msg string) {
-	s.captureCommit(msg)
+// Stack metadata is optional — pass empty strings for non-stack commits.
+func (s *CommitService) CaptureCommit(msg string, stackID string, stackBranch string) {
+	s.captureCommit(msg, stackID, stackBranch)
 }
 
 // captureCommit captures the commit metadata after a successful git commit.
@@ -199,7 +200,8 @@ func (s *CommitService) CaptureCommit(msg string) {
 // current date, constructs a CommitEntry, and appends it to the CommitStore.
 // If commitStore is nil, it's a no-op. Append failures are logged but do not
 // fail the commit operation.
-func (s *CommitService) captureCommit(msg string) {
+// Optional stackID and stackBranch parameters preserve stack metadata from PREVIEW.
+func (s *CommitService) captureCommit(msg string, stackID string, stackBranch string) {
 	if s.commitStore == nil {
 		return
 	}
@@ -224,6 +226,12 @@ func (s *CommitService) captureCommit(msg string) {
 	opts := []domain.CommitEntryOption{domain.WithDate(date)}
 	if author != "" {
 		opts = append(opts, domain.WithAuthor(author))
+	}
+	if stackID != "" {
+		opts = append(opts, domain.WithStackID(stackID))
+	}
+	if stackBranch != "" {
+		opts = append(opts, domain.WithStackBranch(stackBranch))
 	}
 
 	entry, err := domain.NewCommitEntry(sha, msg, opts...)

--- a/internal/workflow/commit_filter.go
+++ b/internal/workflow/commit_filter.go
@@ -122,3 +122,30 @@ func filterForChangelog(commits string, cfg *domain.ProjectConfig) map[string][]
 	}
 	return groups
 }
+
+// filterEntriesForChangelog filters []CommitEntry for changelog generation.
+// It removes commits whose scope matches excluded paths (via IsExcluded)
+// and skips non-user-facing types (chore, test, ci, build) unless breaking.
+// If cfg is nil, DefaultExcluded is used by IsExcluded.
+func filterEntriesForChangelog(entries []domain.CommitEntry, cfg *domain.ProjectConfig) []domain.CommitEntry {
+	var filtered []domain.CommitEntry
+	for _, entry := range entries {
+		c, ok := parseConventionalCommit(entry.Message())
+		if !ok {
+			// Non-conventional commit — include it (conservative)
+			filtered = append(filtered, entry)
+			continue
+		}
+		if skipTypes[c.commitType] && !c.breaking {
+			continue
+		}
+		// Exclude by scope matching excluded paths
+		if cfg != nil && c.scope != "" {
+			if cfg.IsExcluded(c.scope) {
+				continue
+			}
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}

--- a/internal/workflow/release.go
+++ b/internal/workflow/release.go
@@ -383,6 +383,9 @@ func (s *ReleaseService) Prepare(instruction string, userBump string) (*domain.R
 		}
 	}
 	if !fromStore {
+		// Bug 4: Clear pendingEntries before git-history fallback to prevent stale entries from previous release
+		s.pendingEntries = nil
+		
 		if intent.TagName != "" {
 			// intent.TagName is the NEW tag to release. Use the previous tag as reference.
 			prevTag := previousTag(releasesList, intent.TagName)

--- a/internal/workflow/release_capture_test.go
+++ b/internal/workflow/release_capture_test.go
@@ -360,6 +360,39 @@ func TestReleaseService_Prepare_StoreWithDataSkipsGitFallback(t *testing.T) {
 	}
 }
 
+// Bug 4: pendingEntries cleared before git-history fallback
+func TestReleaseService_Prepare_EmptyStore_ClearsPendingEntries(t *testing.T) {
+	// Simulate a scenario where pendingEntries was populated by a previous release,
+	// then the store is empty (post-release clear). Prepare should set pendingEntries to nil.
+	git := &mockGitForRelease{
+		listTagsResult: []string{"v1.0.0"},
+		commitsResult:  "feat: from git fallback",
+	}
+	llm := &mockLLMForRelease{}
+	store := &releaseStoreMock{
+		entries: []domain.CommitEntry{}, // empty store
+	}
+
+	svc := newReleaseSvcWithStore(t, git, llm, store)
+	// Simulate stale pendingEntries from previous release
+	staleEntry, _ := domain.NewCommitEntry("aaa0000", "feat: stale entry")
+	svc.pendingEntries = []domain.CommitEntry{staleEntry}
+
+	intent, commits, _, err := svc.Prepare("release minor version", "")
+	if err != nil {
+		t.Fatalf("Prepare() error: %v", err)
+	}
+
+	// Bug 4: pendingEntries should be cleared (set to nil) before git fallback
+	if svc.pendingEntries != nil {
+		t.Errorf("Prepare() should set pendingEntries to nil before git fallback, got %d entries", len(svc.pendingEntries))
+	}
+	if !strings.Contains(commits, "from git fallback") {
+		t.Errorf("Prepare() should use git fallback commits, got: %s", commits)
+	}
+	_ = intent // used above
+}
+
 // --- Helpers ---
 
 func newReleaseSvcWithStore(t *testing.T, git *mockGitForRelease, llm *mockLLMForRelease, store ports.CommitStore) *ReleaseService {

--- a/internal/workflow/release_generate.go
+++ b/internal/workflow/release_generate.go
@@ -226,13 +226,14 @@ func shouldChunkChangelog(groups map[string][]string, tokenThreshold int) bool {
 func (s *ReleaseService) generateWithStacks(commits string) (string, []string, bool, error) {
 	// Use stored entries from Prepare() if available (they have stack metadata)
 	// Otherwise fall back to parsing the raw commit string (no stack grouping possible)
-	var groups map[string][]domain.CommitEntry
+	var filteredEntries []domain.CommitEntry
 	if len(s.pendingEntries) > 0 {
-		groups = domain.GroupByStackID(s.pendingEntries)
+		// Bug 5: Filter pendingEntries before grouping — exclude skipTypes (unless breaking) and excluded paths
+		filteredEntries = filterEntriesForChangelog(s.pendingEntries, s.projectCfg)
 	}
 
 	// If no stack entries (e.g., on trunk with no entries), fall back to area-based
-	if len(groups) == 0 {
+	if len(filteredEntries) == 0 {
 		if len(commits) == 0 {
 			return "", nil, false, nil
 		}
@@ -242,6 +243,8 @@ func (s *ReleaseService) generateWithStacks(commits string) (string, []string, b
 		}
 		return "", nil, false, nil
 	}
+
+	groups := domain.GroupByStackID(filteredEntries)
 
 	// Build formatted groups and name map for LLM
 	// For each stack group, format commit messages for the LLM prompt.

--- a/internal/workflow/release_generate_test.go
+++ b/internal/workflow/release_generate_test.go
@@ -736,10 +736,10 @@ func TestGenerateWithStacks_UnspecifiedGroupFallback(t *testing.T) {
 
 	// Entries: one with StackID, one without (Unspecified group)
 	e1, _ := domain.NewCommitEntry("aaa0000000000000000000000000000000000000", "feat(auth): add login", domain.WithStackID("abc123"), domain.WithStackBranch("feature/auth"))
-	e2, _ := domain.NewCommitEntry("bbb0000000000000000000000000000000000000", "chore: update deps") // No stack fields
+	e2, _ := domain.NewCommitEntry("bbb0000000000000000000000000000000000000", "feat: update deps") // No stack fields, but feat type (not filtered)
 	svc.pendingEntries = []domain.CommitEntry{e1, e2}
 
-	commits := "aaa0000 feat(auth): add login\nbbb0000 chore: update deps"
+	commits := "aaa0000 feat(auth): add login\nbbb0000 feat: update deps"
 	changelog, _, _, err := svc.Generate(commits)
 	if err != nil {
 		t.Fatalf("Generate() error: %v", err)
@@ -841,4 +841,94 @@ func (m *mockGroupedLLM) RegenerateMessage(prev []string, feedback string, chunk
 func (m *mockGroupedLLM) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) { return nil, nil }
 func (m *mockGroupedLLM) ClassifyBinary(prompt string) (string, error) {
 	return "fix", nil
+}
+
+// --- Bug 5: Stack-mode filtering tests ---
+
+func TestFilterEntriesForChangelog_ExcludesInternalTypes(t *testing.T) {
+	// Bug 5: Stack mode should exclude test/chore/ci/build unless breaking
+	e1, _ := domain.NewCommitEntry("aaa0000000000000000000000000000000000000", "feat: add feature")
+	e2, _ := domain.NewCommitEntry("bbb0000000000000000000000000000000000000", "test: add tests")
+	e3, _ := domain.NewCommitEntry("ccc0000000000000000000000000000000000000", "chore: update deps")
+	e4, _ := domain.NewCommitEntry("ddd0000000000000000000000000000000000000", "ci: fix pipeline")
+	e5, _ := domain.NewCommitEntry("eee0000000000000000000000000000000000000", "build: update docker")
+
+	entries := []domain.CommitEntry{e1, e2, e3, e4, e5}
+	filtered := filterEntriesForChangelog(entries, nil)
+
+	if len(filtered) != 1 {
+		t.Errorf("filterEntriesForChangelog should exclude internal types, got %d entries", len(filtered))
+	}
+	if filtered[0].Message() != "feat: add feature" {
+		t.Errorf("expected feat commit, got %q", filtered[0].Message())
+	}
+}
+
+func TestFilterEntriesForChangelog_BreakingNotFiltered(t *testing.T) {
+	// Bug 5: Breaking internal commits should NOT be filtered
+	e1, _ := domain.NewCommitEntry("aaa0000000000000000000000000000000000000", "test!: breaking test")
+	e2, _ := domain.NewCommitEntry("bbb0000000000000000000000000000000000000", "chore!: breaking chore")
+
+	entries := []domain.CommitEntry{e1, e2}
+	filtered := filterEntriesForChangelog(entries, nil)
+
+	if len(filtered) != 2 {
+		t.Errorf("breaking commits should not be filtered, got %d entries", len(filtered))
+	}
+}
+
+func TestFilterEntriesForChangelog_ExcludedPaths(t *testing.T) {
+	// Bug 5: Excluded paths should be filtered in stack mode
+	cfg := &domain.ProjectConfig{
+		Excluded: []string{"docs", "scripts"},
+	}
+	e1, _ := domain.NewCommitEntry("aaa0000000000000000000000000000000000000", "feat(core): add feature")
+	e2, _ := domain.NewCommitEntry("bbb0000000000000000000000000000000000000", "docs(docs): update readme")
+	e3, _ := domain.NewCommitEntry("ccc0000000000000000000000000000000000000", "chore(scripts): update build")
+
+	entries := []domain.CommitEntry{e1, e2, e3}
+	filtered := filterEntriesForChangelog(entries, cfg)
+
+	if len(filtered) != 1 {
+		t.Errorf("filterEntriesForChangelog should exclude docs/scripts, got %d entries", len(filtered))
+	}
+	if filtered[0].Message() != "feat(core): add feature" {
+		t.Errorf("expected feat(core) commit, got %q", filtered[0].Message())
+	}
+}
+
+func TestGenerateWithStacks_FiltersInternalCommits(t *testing.T) {
+	// Bug 5: generateWithStacks should filter internal commits before grouping
+	git := &mockGitForRelease{}
+	llm := &mockGroupedLLM{
+		result: domain.ChangelogByArea{
+			"feature/auth": []string{"Added authentication"},
+		},
+	}
+	chunker := &mockLogChunker{}
+	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
+	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
+	svc.projectCfg = &domain.ProjectConfig{
+		BaseBranch: "main",
+	}
+
+	// Mix of user-facing and internal commits
+	e1, _ := domain.NewCommitEntry("aaa", "feat(auth): add login", domain.WithStackID("abc123"), domain.WithStackBranch("feature/auth"))
+	e2, _ := domain.NewCommitEntry("bbb", "test(auth): add tests", domain.WithStackID("abc123"), domain.WithStackBranch("feature/auth"))
+	e3, _ := domain.NewCommitEntry("ccc", "chore(auth): cleanup", domain.WithStackID("abc123"), domain.WithStackBranch("feature/auth"))
+	svc.pendingEntries = []domain.CommitEntry{e1, e2, e3}
+
+	changelog, _, _, err := svc.Generate("aaa feat(auth): add login\nbbb test(auth): add tests\nccc chore(auth): cleanup")
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	// LLM should only see the feat commit, not test/chore
+	if !llm.groupedCalled {
+		t.Error("GenerateChangelogGrouped should have been called")
+	}
+	// The changelog should only contain the feat commit
+	if !strings.Contains(changelog, "Added authentication") {
+		t.Errorf("changelog should contain feat commit, got:\n%s", changelog)
+	}
 }


### PR DESCRIPTION
## Summary

- **Bug 1**: MergeBase falla con BaseBranch configurado → error claro, no más full log history
- **Bug 2**: Stack metadata (StackID/StackBranch) viaja de PREVIEW a APPLY vía BgJob
- **Bug 3**: Plumbing amend re-stagea .git-courer/ post-CaptureCommit
- **Bug 4**: pendingEntries se limpia antes del git-history fallback
- **Bug 5**: generateWithStacks() filtra commits internos con filterEntriesForChangelog

## Changes

| File | Change |
|------|--------|
| internal/delivery/mcp/core/commit_handler.go | Bug 1, 2, 3 |
| internal/delivery/mcp/core/handler_test.go | Tests |
| internal/workflow/commit_execute.go | CaptureCommit extendido |
| internal/workflow/commit_filter.go | filterEntriesForChangelog |
| internal/workflow/release.go | Bug 4 |
| internal/workflow/release_generate.go | Bug 5 |
| internal/workflow/release_capture_test.go | Bug 4 test |
| internal/workflow/release_generate_test.go | Bug 5 tests |

## Test Plan

- [x] make test-unit — 33/33 paquetes verdes
- [x] Sin conflictos con stacks-v2.2-phase3

Chained from #116.