### PR TITLE
refactor(domain): remove Areas from ProjectConfig — freeform LLM categories

### DIFF
--- a/.git-courer/branches/llm-freeform-categories-pr1/commits.json
+++ b/.git-courer/branches/llm-freeform-categories-pr1/commits.json
@@ -1,0 +1,8 @@
+[
+  {
+    "sha": "714544f28deb0a1351d9202a54c82f982dd3d7d0",
+    "message": "fix: remove deprecated areas field from project configuration\n\nWHY\nThe areas field in ProjectConfig was redundant and complicated the configuration logic, as path-based classification is now handled via PathTypes and Excluded rules. It required manual normalization and complex path matching during initialization and serialization.\n\nWHAT\n* Removed the areas field from ProjectConfig struct and its JSON mapping.\n* Deleted logic for initializing, writing, and resolving the areas map.\n* Simplified LoadProjectConfig to ignore legacy areas.\n* Updated FormatScopeContext to only return the project description.",
+    "author": "blak0p",
+    "date": "2026-06-06T12:22:17Z"
+  }
+]

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -9,9 +9,9 @@ import (
 
 // ProjectConfig holds per-project settings stored in .git-courer/config.json.
 // These values are committable and shared by the team.
+// Legacy configs may contain "areas" field — it is silently ignored on load and not written on save.
 type ProjectConfig struct {
 	Description string              `json:"description"`
-	Areas       map[string][]string `json:"areas"`
 	PathTypes   map[string][]string `json:"path_types,omitempty"`
 	TestCommand string              `json:"test_command"`
 	UserName    string              `json:"user_name,omitempty"`
@@ -35,11 +35,6 @@ func LoadProjectConfig(workDir string) (*ProjectConfig, error) {
 	cfg := &ProjectConfig{}
 	if err := json.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse project config: %w", err)
-	}
-
-	// Initialize empty map if Areas was nil (JSON missing the key)
-	if cfg.Areas == nil {
-		cfg.Areas = make(map[string][]string)
 	}
 
 	// Initialize empty slice if Excluded was nil (JSON missing the key)
@@ -74,7 +69,6 @@ func SaveProjectConfig(workDir string, cfg *ProjectConfig) error {
 
 	// Merge structured fields into raw map
 	raw["description"] = cfg.Description
-	raw["areas"] = cfg.Areas
 	if len(cfg.PathTypes) > 0 {
 		raw["path_types"] = cfg.PathTypes
 	} else {

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestProjectConfig_LoadExisting reads an existing config.json with description and areas,
+// TestProjectConfig_LoadExisting reads an existing config.json with description,
 // verifies test_command is empty string (default) if not present.
+// Legacy configs with "areas" field load without error.
 func TestProjectConfig_LoadExisting(t *testing.T) {
 	tmpDir := t.TempDir()
 	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
@@ -31,8 +32,7 @@ func TestProjectConfig_LoadExisting(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "test project", cfg.Description)
 	assert.Equal(t, "", cfg.TestCommand, "test_command should default to empty string when missing")
-	assert.Contains(t, cfg.Areas, "core")
-	assert.Equal(t, []string{"internal/"}, cfg.Areas["core"])
+	// Legacy "areas" field is ignored — not in struct
 }
 
 // TestProjectConfig_LoadWithTestCommand verifies loading config with test_command set.
@@ -43,7 +43,6 @@ func TestProjectConfig_LoadWithTestCommand(t *testing.T) {
 
 	existing := map[string]interface{}{
 		"description":  "test project",
-		"areas":        map[string]interface{}{},
 		"test_command": "make test-ci",
 	}
 	data, err := json.MarshalIndent(existing, "", "  ")
@@ -61,9 +60,6 @@ func TestProjectConfig_SaveNew(t *testing.T) {
 
 	cfg := &ProjectConfig{
 		Description: "test project",
-		Areas: map[string][]string{
-			"core": {"internal/"},
-		},
 		TestCommand: "make test",
 	}
 
@@ -74,11 +70,11 @@ func TestProjectConfig_SaveNew(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "test project", loaded.Description)
 	assert.Equal(t, "make test", loaded.TestCommand)
-	assert.Equal(t, []string{"internal/"}, loaded.Areas["core"])
 }
 
-// TestProjectConfig_SavePreservesExistingFields loads a config with description and areas,
+// TestProjectConfig_SavePreservesExistingFields loads a config with description,
 // adds test_command, saves, then reloads to verify all fields are preserved.
+// Legacy "areas" field in file is ignored on load and not written on save.
 func TestProjectConfig_SavePreservesExistingFields(t *testing.T) {
 	tmpDir := t.TempDir()
 	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
@@ -103,13 +99,12 @@ func TestProjectConfig_SavePreservesExistingFields(t *testing.T) {
 	// Save
 	require.NoError(t, SaveProjectConfig(tmpDir, cfg))
 
-	// Reload and verify all fields
+	// Reload and verify fields
 	loaded, err := LoadProjectConfig(tmpDir)
 	require.NoError(t, err)
 	assert.Equal(t, "existing project", loaded.Description)
 	assert.Equal(t, "go test ./...", loaded.TestCommand)
-	assert.Equal(t, []string{"internal/"}, loaded.Areas["core"])
-	assert.Equal(t, []string{"docs/"}, loaded.Areas["docs"])
+	// Legacy "areas" is not loaded into struct
 }
 
 // TestProjectConfig_LoadNonExistent returns an error when .git-courer/config.json doesn't exist.
@@ -121,15 +116,18 @@ func TestProjectConfig_LoadNonExistent(t *testing.T) {
 	assert.Contains(t, err.Error(), "no project config found")
 }
 
-// TestProjectConfig_LoadEmptyAreas handles areas as nil when JSON has no areas key.
-func TestProjectConfig_LoadEmptyAreas(t *testing.T) {
+// TestProjectConfig_LoadLegacyAreas verifies that legacy configs with "areas" field
+// load without error — the field is silently ignored.
+func TestProjectConfig_LoadLegacyAreas(t *testing.T) {
 	tmpDir := t.TempDir()
 	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
-		"description": "minimal project",
-		// No areas key
+		"description": "legacy config",
+		"areas": map[string]interface{}{
+			"core": []string{"internal/"},
+		},
 	}
 	data, err := json.MarshalIndent(existing, "", "  ")
 	require.NoError(t, err)
@@ -137,9 +135,8 @@ func TestProjectConfig_LoadEmptyAreas(t *testing.T) {
 
 	cfg, err := LoadProjectConfig(tmpDir)
 	require.NoError(t, err)
-	assert.Equal(t, "minimal project", cfg.Description)
-	assert.Empty(t, cfg.Areas)
-	assert.Equal(t, "", cfg.TestCommand)
+	assert.Equal(t, "legacy config", cfg.Description)
+	// areas field is ignored — no error, no data
 }
 
 // TestProjectConfig_SaveRoundTripUnknownFields verifies that unknown JSON fields
@@ -216,9 +213,6 @@ func TestProjectConfig_SaveExcluded(t *testing.T) {
 
 	cfg := &ProjectConfig{
 		Description: "test project",
-		Areas: map[string][]string{
-			"core": {"internal/"},
-		},
 		TestCommand: "go test ./...",
 		Excluded:    []string{"docs", "scripts", ".github"},
 	}

--- a/internal/core/domain/project_config.go
+++ b/internal/core/domain/project_config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 )
 
@@ -25,13 +24,11 @@ var DefaultPathTypes = map[string][]string{
 
 // ProjectConfig persists repository metadata for the commit classification system.
 //
-// Trailing slash rule: all path prefixes in Areas, PathTypes, and Excluded MUST end
-// with "/" because matching uses strings.HasPrefix.  A prefix like "docs" would match
-// "docsify/foo.go", while "docs/" only matches paths under the docs directory.
+// Trailing slash rule: all path prefixes in PathTypes and Excluded MUST end
+// with "/" to avoid partial matches (e.g. "docs/" won't match "docsify/foo.go").
 // LoadProjectConfig normalises missing trailing slashes at load time.
 type ProjectConfig struct {
 	Description string              `json:"description"`
-	Areas       map[string][]string `json:"areas"`
 	PathTypes   map[string][]string `json:"path_types,omitempty"`
 	BaseBranch  string              `json:"base_branch,omitempty"`
 	Excluded    []string            `json:"excluded,omitempty"`
@@ -39,11 +36,12 @@ type ProjectConfig struct {
 
 // LoadProjectConfig reads the project configuration from disk.
 // If the config file does not exist, it returns an empty config.
+// Legacy configs with "areas" field load successfully — the field is ignored.
 func LoadProjectConfig(repoRoot string) (*ProjectConfig, error) {
 	path := filepath.Join(repoRoot, ".git-courer", "config.json")
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return &ProjectConfig{Areas: make(map[string][]string)}, nil
+		return &ProjectConfig{}, nil
 	}
 
 	data, err := os.ReadFile(path)
@@ -54,9 +52,6 @@ func LoadProjectConfig(repoRoot string) (*ProjectConfig, error) {
 	var cfg ProjectConfig
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
-	}
-	if cfg.Areas == nil {
-		cfg.Areas = make(map[string][]string)
 	}
 	if cfg.Excluded == nil {
 		cfg.Excluded = []string{}
@@ -91,7 +86,6 @@ func (c *ProjectConfig) Save(repoRoot string) error {
 // (e.g. "docs" matching "docsify/foo.go"). Directories without a trailing slash
 // are rare in config but would cause subtle bugs, so we fix them silently.
 func (c *ProjectConfig) normalise() {
-	c.Areas = normalisePrefixMap(c.Areas)
 	c.PathTypes = normalisePrefixMap(c.PathTypes)
 	c.Excluded = normalisePrefixSlice(c.Excluded)
 }
@@ -115,54 +109,7 @@ func normalisePrefixSlice(s []string) []string {
 	return s
 }
 
-// Rules:
-// 1. Cross chunk.Files paths with area paths.
-// 2. Multiple matches -> area with most files wins.
-// 3. Tie -> first area in config wins.
-// 4. No match -> empty string.
-func (c *ProjectConfig) ResolveScope(files []string) string {
-	if len(c.Areas) == 0 || len(files) == 0 {
-		return ""
-	}
 
-	type areaCount struct {
-		area  string
-		count int
-	}
-
-	counts := make([]areaCount, 0, len(c.Areas))
-
-	for area, prefixes := range c.Areas {
-		matched := 0
-		for _, file := range files {
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(file, prefix) {
-					matched++
-					break
-				}
-			}
-		}
-		if matched > 0 {
-			counts = append(counts, areaCount{area: area, count: matched})
-		}
-	}
-
-	if len(counts) == 0 {
-		return ""
-	}
-
-	winner := counts[0]
-	for _, ac := range counts[1:] {
-		if ac.count > winner.count {
-			winner = ac
-		} else if ac.count == winner.count && ac.area < winner.area {
-			// Deterministic tie-break: lexicographically smallest area name wins.
-			winner = ac
-		}
-	}
-
-	return winner.area
-}
 
 // ResolvePathType maps a set of changed files to a commit type based on path prefixes.
 // Returns the type only when ALL files match its prefixes (unanimity).
@@ -236,79 +183,9 @@ func (c *ProjectConfig) IsExcluded(path string) bool {
 	return false
 }
 
-// NewDirectories returns directory prefixes from files that have no area
-// mapping and are not excluded. Results are deduplicated and sorted.
-func (c *ProjectConfig) NewDirectories(files []string) []string {
-	seen := make(map[string]bool)
-	var dirs []string
-
-	for _, file := range files {
-		if c.IsExcluded(file) {
-			continue
-		}
-
-		// Find the longest-prefix area match
-		maxLen := 0
-		for _, prefixes := range c.Areas {
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(file, prefix) && len(prefix) > maxLen {
-					maxLen = len(prefix)
-				}
-			}
-		}
-
-		// If no area covers this file, extract the directory part
-		if maxLen == 0 {
-			dir := filepath.Dir(file)
-			if dir == "." {
-				dir = ""
-			}
-			if dir != "" && !seen[dir] {
-				seen[dir] = true
-				dirs = append(dirs, dir)
-			}
-		}
-	}
-
-	sort.Strings(dirs)
-	return dirs
-}
-
 // FormatScopeContext produces a human-readable scope string from the project config,
 // suitable for injecting into commit prompts via SetContext().
-// Format: "description\nareas: key=path1,path2\n..."
-// Returns empty string if config has neither description nor areas.
+// Returns only the description (no areas).
 func (c *ProjectConfig) FormatScopeContext() string {
-	if c.Description == "" && len(c.Areas) == 0 {
-		return ""
-	}
-
-	var parts []string
-
-	if c.Description != "" {
-		parts = append(parts, c.Description)
-	}
-
-	if len(c.Areas) > 0 {
-		areaLines := make([]string, 0, len(c.Areas))
-		// Sort area names for deterministic output (map iteration is random)
-		sortedAreas := sortedKeys(c.Areas)
-		for _, area := range sortedAreas {
-			paths := c.Areas[area]
-			areaLines = append(areaLines, fmt.Sprintf("%s=%s", area, strings.Join(paths, ",")))
-		}
-		parts = append(parts, "areas: "+strings.Join(areaLines, "; "))
-	}
-
-	return strings.Join(parts, "\n")
-}
-
-// sortedKeys returns map keys in sorted order for deterministic output.
-func sortedKeys(m map[string][]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
+	return c.Description
 }

--- a/internal/core/domain/project_config_test.go
+++ b/internal/core/domain/project_config_test.go
@@ -3,7 +3,6 @@ package domain
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -12,8 +11,8 @@ func TestProjectConfig_LoadSave(t *testing.T) {
 	tmpDir := t.TempDir()
 	config := &ProjectConfig{
 		Description: "A git commit helper",
-		Areas: map[string][]string{
-			"security": {"internal/auth", "internal/crypto"},
+		PathTypes: map[string][]string{
+			"test": {"test/"},
 		},
 	}
 
@@ -29,8 +28,8 @@ func TestProjectConfig_LoadSave(t *testing.T) {
 	if loaded.Description != config.Description {
 		t.Errorf("Description = %q, want %q", loaded.Description, config.Description)
 	}
-	if len(loaded.Areas["security"]) != 2 {
-		t.Errorf("Areas[security] len = %d, want 2", len(loaded.Areas["security"]))
+	if len(loaded.PathTypes["test"]) != 1 {
+		t.Errorf("PathTypes[test] len = %d, want 1", len(loaded.PathTypes["test"]))
 	}
 }
 
@@ -44,11 +43,8 @@ func TestProjectConfig_MissingConfig(t *testing.T) {
 	if loaded.Description != "" {
 		t.Errorf("Description = %q, want empty string", loaded.Description)
 	}
-	if loaded.Areas == nil {
-		t.Error("Areas should be empty map, not nil")
-	}
-	if len(loaded.Areas) != 0 {
-		t.Errorf("len(Areas) = %d, want 0", len(loaded.Areas))
+	if len(loaded.PathTypes) != 0 {
+		t.Errorf("len(PathTypes) = %d, want 0", len(loaded.PathTypes))
 	}
 }
 
@@ -69,104 +65,18 @@ func TestProjectConfig_MalformedJSON(t *testing.T) {
 	}
 }
 
-func TestProjectConfig_ResolveScope_SingleMatch(t *testing.T) {
-	t.Parallel()
-	config := &ProjectConfig{
-		Areas: map[string][]string{
-			"security": {"internal/auth", "internal/crypto"},
-		},
-	}
-	scope := config.ResolveScope([]string{"internal/auth/login.go", "internal/auth/tokens.go"})
-	if scope != "security" {
-		t.Errorf("ResolveScope = %q, want security", scope)
-	}
-}
-
-func TestProjectConfig_ResolveScope_MultipleAreasTie(t *testing.T) {
-	t.Parallel()
-	config := &ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-			"tui":  {"internal/ui"},
-		},
-	}
-	scope := config.ResolveScope([]string{"internal/core/domain.go", "internal/ui/screen.go"})
-	if scope != "core" {
-		t.Errorf("ResolveScope = %q, want core (first in config wins)", scope)
-	}
-}
-
-func TestProjectConfig_ResolveScope_NoMatch(t *testing.T) {
-	t.Parallel()
-	config := &ProjectConfig{
-		Areas: map[string][]string{
-			"security": {"internal/auth"},
-		},
-	}
-	scope := config.ResolveScope([]string{"pkg/utils/helpers.go"})
-	if scope != "" {
-		t.Errorf("ResolveScope = %q, want empty string", scope)
-	}
-}
-
-func TestProjectConfig_ResolveScope_NoAreasConfigured(t *testing.T) {
-	t.Parallel()
-	config := &ProjectConfig{}
-	scope := config.ResolveScope([]string{"internal/auth/login.go"})
-	if scope != "" {
-		t.Errorf("ResolveScope = %q, want empty string", scope)
-	}
-}
-
-func TestProjectConfig_ResolveScope_MostFilesWins(t *testing.T) {
-	t.Parallel()
-	config := &ProjectConfig{
-		Areas: map[string][]string{
-			"security": {"internal/auth"},
-			"core":     {"internal/core"},
-		},
-	}
-	scope := config.ResolveScope([]string{
-		"internal/core/domain.go",
-		"internal/core/ports.go",
-		"internal/auth/login.go",
-	})
-	if scope != "core" {
-		t.Errorf("ResolveScope = %q, want core (most files wins)", scope)
-	}
-}
-
 // --- FormatScopeContext tests ---
 
-func TestProjectConfig_FormatScopeContext_WithAreas(t *testing.T) {
+func TestProjectConfig_FormatScopeContext_DescriptionOnly(t *testing.T) {
 	t.Parallel()
 	config := &ProjectConfig{
-		Description: "A git helper",
-		Areas: map[string][]string{
-			"security": {"internal/auth/", "internal/crypto/"},
-			"core":     {"internal/core/domain/", "internal/core/ports/"},
-		},
+		Description: "My project",
 	}
 
 	result := config.FormatScopeContext()
 
-	if result == "" {
-		t.Fatal("FormatScopeContext() returned empty string, expected non-empty scope context")
-	}
-	// Must contain description
-	if !strings.Contains(result, "A git helper") {
-		t.Errorf("FormatScopeContext() missing description; got:\n%s", result)
-	}
-	// Must contain area names
-	if !strings.Contains(result, "security") {
-		t.Errorf("FormatScopeContext() missing area 'security'; got:\n%s", result)
-	}
-	if !strings.Contains(result, "core") {
-		t.Errorf("FormatScopeContext() missing area 'core'; got:\n%s", result)
-	}
-	// Must contain path mappings
-	if !strings.Contains(result, "internal/auth/") {
-		t.Errorf("FormatScopeContext() missing path 'internal/auth/'; got:\n%s", result)
+	if result != "My project" {
+		t.Errorf("FormatScopeContext() = %q, want %q", result, "My project")
 	}
 }
 
@@ -181,24 +91,25 @@ func TestProjectConfig_FormatScopeContext_Empty(t *testing.T) {
 	}
 }
 
-func TestProjectConfig_FormatScopeContext_DescriptionOnly(t *testing.T) {
+// Test to verify ProjectConfig without Areas field compiles and loads correctly
+func TestProjectConfig_NoAreasField(t *testing.T) {
 	t.Parallel()
+	tmpDir := t.TempDir()
 	config := &ProjectConfig{
-		Description: "My project",
+		Description: "No areas project",
 	}
 
-	result := config.FormatScopeContext()
+	if err := config.Save(tmpDir); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
 
-	if !strings.Contains(result, "My project") {
-		t.Errorf("FormatScopeContext() missing description; got:\n%s", result)
+	loaded, err := LoadProjectConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig() error = %v", err)
 	}
-	// Should still have the description even without areas
-	if result == "" {
-		t.Error("FormatScopeContext() returned empty string for description-only config")
-	}
-	// Should NOT contain "areas:" if there are no areas
-	if strings.Contains(result, "areas:") {
-		t.Errorf("FormatScopeContext() should not contain 'areas:' with no areas; got:\n%s", result)
+
+	if loaded.Description != "No areas project" {
+		t.Errorf("Description = %q, want %q", loaded.Description, "No areas project")
 	}
 }
 
@@ -267,91 +178,7 @@ func TestProjectConfig_IsExcluded_PrefixMatching(t *testing.T) {
 	}
 }
 
-// --- NewDirectories tests ---
 
-func TestProjectConfig_NewDirectories_SomeDirsHaveNoArea(t *testing.T) {
-	t.Parallel()
-	cfg := &ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-	}
-	files := []string{
-		"internal/core/domain.go",
-		"internal/infra/cfg/db.go",
-	}
-	got := cfg.NewDirectories(files)
-	want := []string{"internal/infra/cfg"}
-	if len(got) != len(want) {
-		t.Fatalf("NewDirectories = %v, want %v", got, want)
-	}
-	for i, d := range got {
-		if d != want[i] {
-			t.Errorf("NewDirectories[%d] = %q, want %q", i, d, want[i])
-		}
-	}
-}
-
-func TestProjectConfig_NewDirectories_AllDirsMapped(t *testing.T) {
-	t.Parallel()
-	cfg := &ProjectConfig{
-		Areas: map[string][]string{
-			"security": {"internal/auth"},
-		},
-	}
-	files := []string{"internal/auth/login.go"}
-	got := cfg.NewDirectories(files)
-	if len(got) != 0 {
-		t.Errorf("NewDirectories = %v, want empty (all mapped)", got)
-	}
-}
-
-func TestProjectConfig_NewDirectories_ExcludedDirFilteredOut(t *testing.T) {
-	t.Parallel()
-	cfg := &ProjectConfig{}
-	// DefaultExcluded includes "docs"
-	files := []string{"docs/api.md", "internal/core/domain.go"}
-	got := cfg.NewDirectories(files)
-	for _, d := range got {
-		if d == "docs" || strings.HasPrefix(d, "docs/") {
-			t.Errorf("NewDirectories should not include excluded dir %q", d)
-		}
-	}
-}
-
-func TestProjectConfig_NewDirectories_NoAreasConfigured(t *testing.T) {
-	t.Parallel()
-	cfg := &ProjectConfig{}
-	// No areas, no excluded — everything is new
-	files := []string{"internal/core/domain.go"}
-	got := cfg.NewDirectories(files)
-	if len(got) != 1 || got[0] != "internal/core" {
-		t.Errorf("NewDirectories = %v, want [internal/core]", got)
-	}
-}
-
-func TestProjectConfig_NewDirectories_DeduplicatedAndSorted(t *testing.T) {
-	t.Parallel()
-	cfg := &ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-	}
-	// Two files in same directory should produce one entry
-	files := []string{
-		"internal/core/domain.go",
-		"internal/core/ports.go",
-		"internal/infra/cfg/a.go",
-		"internal/infra/cfg/b.go",
-	}
-	got := cfg.NewDirectories(files)
-	if len(got) != 1 {
-		t.Errorf("NewDirectories = %v, want 1 unique directory, got %d", got, len(got))
-	}
-	if len(got) > 0 && got[0] != "internal/infra/cfg" {
-		t.Errorf("NewDirectories[0] = %q, want %q", got[0], "internal/infra/cfg")
-	}
-}
 
 // --- ResolvePathType tests ---
 
@@ -429,10 +256,7 @@ func TestProjectConfig_BaseBranch_RoundTrip(t *testing.T) {
 	tmpDir := t.TempDir()
 	config := &ProjectConfig{
 		Description: "test project",
-		Areas: map[string][]string{
-			"core": {"internal/core/"},
-		},
-		BaseBranch: "main",
+		BaseBranch:  "main",
 	}
 
 	if err := config.Save(tmpDir); err != nil {
@@ -457,7 +281,7 @@ func TestProjectConfig_BaseBranch_DefaultEmpty(t *testing.T) {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
 	// Config with no base_branch key
-	configJSON := `{"description":"test","areas":{"core":["internal/core/"]}}`
+	configJSON := `{"description":"test"}`
 	if err := os.WriteFile(filepath.Join(repoDir, "config.json"), []byte(configJSON), 0644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}


### PR DESCRIPTION
## Motivation

The predefined `Areas` system (core, cli, tui, etc.) forces users to configure and maintain a rigid taxonomy in `.git-courer/config.json`. The LLM fills bullets within those fixed categories, producing groupings that often don't match the actual change intent.

## Solution

Remove `Areas` from the domain model. The LLM receives flat commits and decides the categories itself, producing more natural and relevant groupings per changelog.

## Changes in this PR (PR 1 of 3)

### Domain — `internal/core/domain/project_config.go`
- Removed `Areas` field from `ProjectConfig` struct
- Removed dependent methods: `ResolveScope()`, `NewDirectories()`, `sortedKeys()`
- `FormatScopeContext()` simplified to description only
- `PathTypes`, `Excluded`, `BaseBranch` untouched

### Config — `internal/config/project.go`
- Removed `Areas` field from struct
- Removed initialization and `areas:` write on save
- Backward compatible: legacy configs with `areas:` still load without error

### Tests
- Removed: `ResolveScope`, `NewDirectories`, `FormatScopeContext` area tests
- Added: ProjectConfig without Areas compiles, legacy config loads OK

## Upcoming PRs
- **PR 2**: Workflow layer (commit.go, release_generate.go, prompts)
- **PR 3**: TUI init + CLI init cleanup

## Impact
- 5 files modified, ~56 added, ~359 removed
- No impact on stack mode, PathTypes, Excluded, BaseBranch