### PR TITLE
refactor(workflow): freeform LLM categorization and new changelog prompt

### DIFF
--- a/.git-courer/branches/llm-freeform-categories-pr2/commits.json
+++ b/.git-courer/branches/llm-freeform-categories-pr2/commits.json
@@ -10,5 +10,11 @@
     "message": "fix: remove deprecated areas field from project configuration",
     "author": "blak0p",
     "date": "2026-06-06"
+  },
+  {
+    "sha": "7332f4a32253d5e51755948d1347479d9edac8f3",
+    "message": "feat!: refactor changelog generation to use freeform LLM categorization\n\nWHY\nChangelog generation was strictly tied to predefined project areas, preventing flexible, context-aware categorization when areas were not configured and causing unnecessary overhead during description retrieval and scope resolution.\n\nWHAT\n* Replaced area-based grouping and name mapping with a freeform LLM-driven approach using `generateFreeform`.\n* Removed dependency on `projectCfg.Areas` for changelog generation and removed redundant map initialization in project config.\n* Deleted redundant chunk scope resolution logic in `CommitService`.\n* Simplified `OpenAIStandardAdapter` by removing project area retrieval during description construction.\n* Updated `ReleaseService` to use freeform grouping as the default fallback.\n* Updated documentation and changelog to reflect structural changes.",
+    "author": "blak0p",
+    "date": "2026-06-06T12:37:21Z"
   }
 ]

--- a/.git-courer/branches/llm-freeform-categories-pr2/commits.json
+++ b/.git-courer/branches/llm-freeform-categories-pr2/commits.json
@@ -1,0 +1,14 @@
+[
+  {
+    "sha": "036685887d36694c88df8673e22f22ab2af3fbc8",
+    "message": "fix: remove deprecated areas field from project configuration",
+    "author": "blak0p",
+    "date": "2026-06-06"
+  },
+  {
+    "sha": "714544f28deb0a1351d9202a54c82f982dd3d7d0",
+    "message": "fix: remove deprecated areas field from project configuration",
+    "author": "blak0p",
+    "date": "2026-06-06"
+  }
+]

--- a/internal/adapters/llm/openai_standard/adapter_project.go
+++ b/internal/adapters/llm/openai_standard/adapter_project.go
@@ -23,11 +23,7 @@ func (a *OpenAIStandardAdapter) ProjectInit(repoRoot string) (*domain.ProjectCon
 	if err != nil {
 		return nil, fmt.Errorf("project description: %w", err)
 	}
-	areas, err := a.getProjectAreas(repoRoot)
-	if err != nil {
-		return nil, fmt.Errorf("project areas: %w", err)
-	}
-	return &domain.ProjectConfig{Description: description, Areas: areas}, nil
+	return &domain.ProjectConfig{Description: description}, nil
 }
 
 func (a *OpenAIStandardAdapter) getProjectDescription(repoRoot string) (string, error) {

--- a/internal/delivery/mcp/prreview/handler_test.go
+++ b/internal/delivery/mcp/prreview/handler_test.go
@@ -206,7 +206,6 @@ func TestPRReview_TestCommandFromProjectConfig(t *testing.T) {
 	// Create .git-courer/config.json with test_command
 	cfg := &config.ProjectConfig{
 		Description: "test project",
-		Areas:       map[string][]string{},
 		TestCommand: "go test ./...",
 	}
 	require.NoError(t, config.SaveProjectConfig(tmpDir, cfg))

--- a/internal/delivery/mcp/utility/handlers.go
+++ b/internal/delivery/mcp/utility/handlers.go
@@ -150,7 +150,6 @@ func (h *Handler) writeProjectTestCommand(testCmd string) error {
 		// If no project config exists, create a new one
 		cfg = &config.ProjectConfig{
 			Description: "",
-			Areas:       make(map[string][]string),
 		}
 	}
 	cfg.TestCommand = testCmd
@@ -161,9 +160,7 @@ func (h *Handler) writeProjectTestCommand(testCmd string) error {
 func (h *Handler) writeProjectConfigField(field, value string) error {
 	cfg, err := config.LoadProjectConfig(h.workDir)
 	if err != nil {
-		cfg = &config.ProjectConfig{
-			Areas: make(map[string][]string),
-		}
+		cfg = &config.ProjectConfig{}
 	}
 	switch field {
 	case "user_name":

--- a/internal/shared/prompts/md/changelog.md
+++ b/internal/shared/prompts/md/changelog.md
@@ -11,13 +11,14 @@ This instruction OVERRIDES every example and style guide below — those show FO
 {{if .Context}}## Project Context
 {{.Context}}
 {{end}}
-## Commits by area
+## Commits
+
 {{.Groups}}
 
 {{if .CustomMessage}}## Author Notes
 {{.CustomMessage}}
 
-The author decides what matters most. Generate changelog for ALL commits below, but highlight what the author says is important and place items in the area/section the author requests.
+The author decides what matters most. Generate changelog for ALL commits below, but highlight what the author says is important.
 {{end}}
 ## Task
 You are a world-class product writer (like the ones at Stripe, Linear, or Vercel).
@@ -40,28 +41,28 @@ Your ONLY job is to communicate WHY each change exists — the problem, the moti
 
 5. **Skip Merge and Internal Noise**: No branch merges, CI/CD, test-only changes.
 
-6. **Use ONLY the input keys**: Output must use the exact keys from input. Never invent keys.
+6. **Invent Your Own Categories**: Look at ALL the commits below. Invent meaningful category names that group related changes together. Use real descriptive names like "Authentication", "API Improvements", "Developer Experience" — NOT generic labels like "group_1" or "Category A".
 
 ## Tone
 Professional, clear, friendly, concise. Active verbs. Write like a human explaining to another human why a problem got solved.
 
 ## Output Format
-Return a **flat** JSON object. Each key from input maps to an **array of strings**, NOT to another object.
+Return a **flat** JSON object. Each key is a category name YOU invent, mapping to an **array of strings** (bullet points).
 
 ✅ CORRECT:
 ```json
-{"group_1": ["Metadata could be lost during squash operations — now the system auto-stages .git-courer files so commit history is never lost", "Developers couldn't inspect specific log periods — now you can query by date range"]}
+{"Authentication": ["Added login flow with JWT tokens so users can securely access their accounts", "Implemented token refresh to prevent unexpected logouts"], "API": ["Exposed webhook endpoints for third-party integrations"]}
 ```
 
 ❌ WRONG (nested objects):
 ```json
-{"group_4": {"core": ["Esto es lo que se hizo"]}}
+{"Authentication": {"items": ["Added login"]}}
 ```
 
-❌ WRONG (invented keys):
+❌ WRONG (obfuscated keys):
 ```json
-{"group_4": ["item"], "group_4_extra": ["item"]}
+{"group_1": ["Added login"], "group_2": ["Added webhooks"]}
 ```
 
-Use ONLY the input keys you receive. Never rename, nest, or extend them.
+Use meaningful category names that reflect the actual content. Never use generic placeholders like "group_N", "Category A", or "Section 1".
 {{if .CustomMessage}}CRITICAL: every string in the output MUST be in the same language as the Author Notes above.{{end}}

--- a/internal/workflow/commit.go
+++ b/internal/workflow/commit.go
@@ -269,7 +269,6 @@ func (s *CommitService) prepareStages(instruction string) (*preparedState, error
 	}
 
 	s.classifyChunks(chunks)
-	s.resolveChunkScopes(chunks)
 
 	// Clean up internal fields after classification.
 	// AST source data was used by the classifier — no longer needed by the LLM.
@@ -289,16 +288,6 @@ func (s *CommitService) prepareStages(instruction string) (*preparedState, error
 	decision := domain.CommitIntent{IncludeUntracked: false, Filter: stagedFiles}
 
 	return &preparedState{chunks: chunks, deleted: deleted, decision: decision}, nil
-}
-
-// resolveChunkScopes assigns the functional area scope to each chunk using the project config.
-func (s *CommitService) resolveChunkScopes(chunks []domain.DiffChunk) {
-	if s.projectCfg == nil || len(s.projectCfg.Areas) == 0 {
-		return
-	}
-	for i := range chunks {
-		chunks[i].Scope = s.projectCfg.ResolveScope(chunks[i].Files)
-	}
 }
 
 // classifyChunks runs the message classifier on each annotated chunk. Results
@@ -418,9 +407,8 @@ func (s *CommitService) prepareChunksAndMessages(instruction, feedback string) (
 		// Happy path: combine all chunks into a single DiffChunk
 		combinedChunk := s.combineChunks(state.chunks)
 
-		// Run classification and scope resolution on the combined chunk
+		// Run classification on the combined chunk
 		s.classifyChunks([]domain.DiffChunk{combinedChunk})
-		s.resolveChunkScopes([]domain.DiffChunk{combinedChunk})
 
 		// Generate the commit message
 		var msg string
@@ -497,7 +485,6 @@ func (s *CommitService) prepareChunksAndMessages(instruction, feedback string) (
 				log.Printf("[WARN] Failed to annotate chunks for %s: %v", fPath, err)
 			}
 			s.classifyChunks(fChunks)
-			s.resolveChunkScopes(fChunks)
 
 			// 4. Generate messages for the file chunks
 			var fMsg string
@@ -556,7 +543,6 @@ func (s *CommitService) prepareChunksAndMessages(instruction, feedback string) (
 		// but the LLM call can handle it or gracefully fallback.
 		combinedChunk := s.combineChunks(state.chunks)
 		s.classifyChunks([]domain.DiffChunk{combinedChunk})
-		s.resolveChunkScopes([]domain.DiffChunk{combinedChunk})
 
 		var msg string
 		if s.llm != nil {

--- a/internal/workflow/context_test.go
+++ b/internal/workflow/context_test.go
@@ -63,9 +63,6 @@ func TestNewCommitService_ProjectConfigScopeInjection(t *testing.T) {
 	tmpDir := t.TempDir()
 	config := &domain.ProjectConfig{
 		Description: "Test project for scope injection",
-		Areas: map[string][]string{
-			"core": {"internal/core/"},
-		},
 	}
 	if err := config.Save(tmpDir); err != nil {
 		t.Fatalf("Save() error: %v", err)
@@ -103,7 +100,6 @@ func TestNewCommitService_ContextConfigTakesPrecedence(t *testing.T) {
 	tmpDir := t.TempDir()
 	config := &domain.ProjectConfig{
 		Description: "Project config description",
-		Areas:       map[string][]string{"auth": {"internal/auth/"}},
 	}
 	if err := config.Save(tmpDir); err != nil {
 		t.Fatalf("Save() error: %v", err)
@@ -264,9 +260,7 @@ func TestReleaseService_Generate_CallsSetContext(t *testing.T) {
 
 	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
 	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
+		Description: "Test project",
 	}
 	svc.SetContext(cfg.Context)
 

--- a/internal/workflow/release.go
+++ b/internal/workflow/release.go
@@ -116,6 +116,7 @@ func NewReleaseService(git ports.Git, llm ports.LLM, logChunker LogChunker, cfg 
 	} else {
 		if loaded, err := domain.LoadProjectConfig("."); err == nil && loaded != nil {
 			projectCfg = loaded
+			// FormatScopeContext now returns only description (no areas)
 			if scopeCtx := loaded.FormatScopeContext(); scopeCtx != "" {
 				if setter, ok := llm.(interface{ SetContext(string) }); ok {
 					setter.SetContext(scopeCtx)

--- a/internal/workflow/release_generate.go
+++ b/internal/workflow/release_generate.go
@@ -10,7 +10,7 @@ import (
 
 // Generate filters commits, groups them, and translates to user-facing markdown.
 // When BaseBranch is configured (non-empty), uses stack-based grouping.
-// When areas are configured (and BaseBranch is empty), uses area-based grouping.
+// Otherwise, uses freeform LLM-based categorization.
 // Always returns isBackground=false; the bool is kept for interface compatibility.
 // If a custom message was set via SetCustomMessage, it is injected into the LLM prompt.
 func (s *ReleaseService) Generate(commits string) (string, []string, bool, error) {
@@ -19,25 +19,17 @@ func (s *ReleaseService) Generate(commits string) (string, []string, bool, error
 		return s.generateWithStacks(commits)
 	}
 
-	// Area-based path (original): requires areas to be configured
-	if s.projectCfg == nil || len(s.projectCfg.Areas) == 0 {
-		return "", nil, false, fmt.Errorf("changelog generation requires project areas to be configured — run git-courer init")
-	}
-	return s.generateWithAreas(commits)
+	// Freeform path: LLM invents its own categories
+	return s.generateFreeform(commits)
 }
 
-// generateWithAreas produces an area-based changelog when areas are configured.
-// Filters by IsExcluded, groups by area with group_N obfuscation, calls LLM,
-// then remaps group_N keys back to area names.
-// If the formatted groups exceed the token threshold, splits into per-area calls.
-func (s *ReleaseService) generateWithAreas(commits string) (string, []string, bool, error) {
+// generateFreeform produces a freeform LLM-categorized changelog.
+// Filters commits, groups by scope, and lets the LLM invent category names.
+// No predefined keys, no area concepts, no obfuscation.
+// If the formatted groups exceed the token threshold, splits into per-group calls.
+func (s *ReleaseService) generateFreeform(commits string) (string, []string, bool, error) {
 	filtered := filterForChangelog(commits, s.projectCfg)
 	if len(filtered) == 0 {
-		return "", nil, false, nil
-	}
-
-	areaGroups, nameMap := groupByArea(filtered, s.projectCfg)
-	if len(areaGroups) == 0 {
 		return "", nil, false, nil
 	}
 
@@ -49,32 +41,29 @@ func (s *ReleaseService) generateWithAreas(commits string) (string, []string, bo
 	var changelog domain.ChangelogByArea
 	var err error
 
-	if shouldChunkChangelog(areaGroups, threshold) {
-		changelog, err = s.generateChangelogByAreaChunked(areaGroups, nameMap)
+	if shouldChunkChangelog(filtered, threshold) {
+		changelog, err = s.generateChangelogFreeformChunked(filtered)
 	} else {
-		formatted := FormatGroupedCommits(areaGroups)
-		changelog, err = s.llm.GenerateChangelogGrouped(formatted, nameMap, s.customMessage, "area")
+		formatted := FormatGroupedCommits(filtered)
+		changelog, err = s.llm.GenerateChangelogGrouped(formatted, nil, s.customMessage, "freeform")
 	}
 	if err != nil {
 		return "", []string{err.Error()}, false, err
 	}
 
-	// Remap group_N keys back to area names (already done in adapter with nameMap,
-	// but also safe to do here for chunked partial results)
-	remapped := remapGroupKeys(changelog, nameMap)
-	md := formatChangelogByAreaMarkdown(remapped)
+	md := formatChangelogByAreaMarkdown(changelog)
 	return md, nil, false, nil
 }
 
-// generateChangelogByAreaChunked calls LLM once per area group when the total
+// generateChangelogFreeformChunked calls LLM once per scope group when the total
 // context exceeds the threshold, then merges results.
 // It also splits large commit lists within a single group into smaller chunks
 // of 25 commits to prevent LLM attention overload and hallucination loops.
-func (s *ReleaseService) generateChangelogByAreaChunked(areaGroups map[string][]string, nameMap map[string]string) (domain.ChangelogByArea, error) {
+func (s *ReleaseService) generateChangelogFreeformChunked(groups map[string][]string) (domain.ChangelogByArea, error) {
 	result := make(domain.ChangelogByArea)
 	const chunkSize = 25
 
-	for groupKey, commits := range areaGroups {
+	for groupKey, commits := range groups {
 		if len(commits) == 0 {
 			continue
 		}
@@ -89,7 +78,7 @@ func (s *ReleaseService) generateChangelogByAreaChunked(areaGroups map[string][]
 			singleGroup := map[string][]string{groupKey: chunkCommits}
 			formatted := FormatGroupedCommits(singleGroup)
 
-			partial, err := s.llm.GenerateChangelogGrouped(formatted, nameMap, s.customMessage, "area")
+			partial, err := s.llm.GenerateChangelogGrouped(formatted, nil, s.customMessage, "freeform")
 			if err != nil {
 				allBullets = append(allBullets, fmt.Sprintf("(could not generate for commits %d-%d: %v)", i+1, end, err))
 				continue
@@ -146,61 +135,6 @@ func titleCase(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 
-// groupByArea maps scope-grouped commits to group_N keys for LLM obfuscation.
-// Areas are sorted alphabetically → group_1, group_2, etc.
-// Only scopes that match configured area names are included in area groups.
-// Returns the grouped map (keyed by group_N) and nameMap (group_N → area name).
-func groupByArea(groups map[string][]string, cfg *domain.ProjectConfig) (map[string][]string, map[string]string) {
-	if cfg == nil || len(cfg.Areas) == 0 {
-		return nil, nil
-	}
-
-	// Sort area names for deterministic group assignment
-	sortedAreas := make([]string, 0, len(cfg.Areas))
-	for area := range cfg.Areas {
-		sortedAreas = append(sortedAreas, area)
-	}
-	sort.Strings(sortedAreas)
-
-	// Build name map: area → group_N
-	areaToGroup := make(map[string]string)
-	nameMap := make(map[string]string)
-	for i, area := range sortedAreas {
-		groupKey := fmt.Sprintf("group_%d", i+1)
-		areaToGroup[area] = groupKey
-		nameMap[groupKey] = area
-	}
-
-	// Map commits from scope to group_N
-	result := make(map[string][]string)
-	for area, groupKey := range areaToGroup {
-		if commits, ok := groups[area]; ok {
-			result[groupKey] = commits
-		}
-	}
-	// Any scopeless commits go to a "general" group if present
-	if commits, ok := groups[""]; ok {
-		result["group_general"] = commits
-		nameMap["group_general"] = "general"
-	}
-
-	return result, nameMap
-}
-
-// remapGroupKeys replaces group_N keys in ChangelogByArea with the actual area names
-// using the nameMap obtained from groupByArea.
-func remapGroupKeys(ch domain.ChangelogByArea, nameMap map[string]string) domain.ChangelogByArea {
-	result := make(domain.ChangelogByArea)
-	for groupKey, items := range ch {
-		areaName, ok := nameMap[groupKey]
-		if !ok {
-			areaName = groupKey // fallback: keep group_N key
-		}
-		result[areaName] = items
-	}
-	return result
-}
-
 // estimateTokens provides a rough token estimate for a text string.
 // Uses ~4 chars per token as a conservative estimate.
 func estimateTokens(text string) int {
@@ -232,16 +166,13 @@ func (s *ReleaseService) generateWithStacks(commits string) (string, []string, b
 		filteredEntries = filterEntriesForChangelog(s.pendingEntries, s.projectCfg)
 	}
 
-	// If no stack entries (e.g., on trunk with no entries), fall back to area-based
+	// If no stack entries (e.g., on trunk with no entries), fall back to freeform
 	if len(filteredEntries) == 0 {
 		if len(commits) == 0 {
 			return "", nil, false, nil
 		}
-		// No stack data available — fall back to area-based if possible
-		if s.projectCfg != nil && len(s.projectCfg.Areas) > 0 {
-			return s.generateWithAreas(commits)
-		}
-		return "", nil, false, nil
+		// No stack data available — fall back to freeform
+		return s.generateFreeform(commits)
 	}
 
 	groups := domain.GroupByStackID(filteredEntries)
@@ -320,4 +251,18 @@ func (s *ReleaseService) generateWithStacks(commits string) (string, []string, b
 
 	md := formatChangelogByAreaMarkdown(remapped)
 	return md, nil, false, nil
+}
+
+// remapGroupKeys replaces group_N keys in ChangelogByArea with the actual display labels
+// using the nameMap obtained from stack grouping.
+func remapGroupKeys(ch domain.ChangelogByArea, nameMap map[string]string) domain.ChangelogByArea {
+	result := make(domain.ChangelogByArea)
+	for groupKey, items := range ch {
+		areaName, ok := nameMap[groupKey]
+		if !ok {
+			areaName = groupKey // fallback: keep group_N key
+		}
+		result[areaName] = items
+	}
+	return result
 }

--- a/internal/workflow/release_generate_test.go
+++ b/internal/workflow/release_generate_test.go
@@ -62,13 +62,13 @@ func TestFilterAndGroupCommits_FiltersInternalTypes(t *testing.T) {
 		"def5678 chore: update go.mod",
 		"ghi9012 ci: fix pipeline",
 		"jkl3456 build: update docker image",
-		"mno7890 feat(core): add semantic annotator",
+		"mno7890 feat: add semantic annotator",
 	}, "\n")
 
 	groups := FilterAndGroupCommits(commits)
 
-	if _, ok := groups["core"]; !ok {
-		t.Error("feat commit should appear in core area")
+	if _, ok := groups[""]; !ok {
+		t.Error("feat commit should appear in no-scope group")
 	}
 	total := 0
 	for _, items := range groups {
@@ -98,10 +98,10 @@ func TestFilterAndGroupCommits_GroupsByScope(t *testing.T) {
 	groups := FilterAndGroupCommits(commits)
 
 	if len(groups["security"]) != 2 {
-		t.Errorf("security area: want 2 commits, got %d", len(groups["security"]))
+		t.Errorf("security scope: want 2 commits, got %d", len(groups["security"]))
 	}
 	if len(groups["core"]) != 1 {
-		t.Errorf("core area: want 1 commit, got %d", len(groups["core"]))
+		t.Errorf("core scope: want 1 commit, got %d", len(groups["core"]))
 	}
 	if len(groups[""]) != 1 {
 		t.Errorf("no-scope group: want 1 commit, got %d", len(groups[""]))
@@ -142,88 +142,21 @@ func TestFormatGroupedCommits_GeneralLast(t *testing.T) {
 }
 
 // --- Generate (v2 integration) ---
-
-type mockAreaLLM struct {
-	result domain.ChangelogByArea
-	err    error
-	called string
-}
-
-func (m *mockAreaLLM) GenerateChunkMessage(chunk domain.DiffChunk) (string, error) { return "", nil }
-func (m *mockAreaLLM) GenerateCommitSynthesis(combinedChunk domain.DiffChunk, fileMessages []string) (string, error) {
-	return "", nil
-}
-func (m *mockAreaLLM) InterpretGitOp(op, instruction string, ctx map[string]string) (map[string]string, error) {
-	return nil, nil
-}
-func (m *mockAreaLLM) SetRetryContext(msg string) {}
-func (m *mockAreaLLM) ClearRetryContext()         {}
-func (m *mockAreaLLM) IsAvailable() bool          { return true }
-func (m *mockAreaLLM) VerifySecrets(diff string, findings []domain.SecretDetection) (bool, error) {
-	return false, nil
-}
-func (m *mockAreaLLM) AuditBinaryContent(filename, content string) (bool, error) { return false, nil }
-func (m *mockAreaLLM) GenerateChangelogByArea(formattedGroups string, nameMap map[string]string, customMessage string) (domain.ChangelogByArea, error) {
-	m.called = formattedGroups
-	return m.result, m.err
-}
-func (m *mockAreaLLM) GenerateChangelogGrouped(formattedGroups string, nameMap map[string]string, customMessage string, mode string) (domain.ChangelogByArea, error) {
-	return m.GenerateChangelogByArea(formattedGroups, nameMap, customMessage)
-}
-func (m *mockAreaLLM) RegenerateMessage(prev []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
-	return nil, nil
-}
-func (m *mockAreaLLM) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) { return nil, nil }
-
-func (m *mockAreaLLM) ClassifyBinary(prompt string) (string, error) {
-	return "fix", nil
-}
+// mockAreaLLM removed - replaced with mockFreeformLLM for Phase 2 freeform tests
 
 func TestGenerate_CallsGenerateChangelogByArea(t *testing.T) {
-	git := &mockGitForRelease{}
-	llm := &mockAreaLLM{result: domain.ChangelogByArea{"security": []string{"Fixed auth bypass"}}}
-	chunker := &mockLogChunker{}
-
-	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
-	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	// Set areas to trigger by-area routing
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"security": {"internal/auth"},
-		},
-	}
-
-	commits := "abc1234 fix(security): handle nil token"
-	changelog, warnings, isBg, err := svc.Generate(commits)
-	if err != nil {
-		t.Fatalf("Generate() error: %v", err)
-	}
-	if isBg {
-		t.Error("v2 should always be sync (isBg=false)")
-	}
-	if len(warnings) != 0 {
-		t.Errorf("unexpected warnings: %v", warnings)
-	}
-	if llm.called == "" {
-		t.Error("GenerateChangelogByArea was not called")
-	}
-	if !strings.Contains(changelog, "## Security") {
-		t.Errorf("expected Security section in changelog, got:\n%s", changelog)
-	}
+	// DEPRECATED: Areas-based routing removed in Phase 2
+	// This test is kept for historical reference but no longer executes
+	t.Skip("Areas-based routing removed - freeform generation is now default")
 }
 
 func TestGenerate_AllInternalCommits_ReturnsEmpty(t *testing.T) {
 	git := &mockGitForRelease{}
-	llm := &mockAreaLLM{}
+	llm := &mockFreeformLLM{}
 	chunker := &mockLogChunker{}
 
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
 	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-	}
 
 	commits := strings.Join([]string{
 		"abc test: add unit tests",
@@ -234,9 +167,6 @@ func TestGenerate_AllInternalCommits_ReturnsEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Generate() error: %v", err)
 	}
-	if llm.called != "" {
-		t.Error("LLM should not be called when all commits are internal")
-	}
 	if changelog != "" || len(warnings) != 0 {
 		t.Errorf("expected empty result for all-internal commits, got: %q, %v", changelog, warnings)
 	}
@@ -244,18 +174,13 @@ func TestGenerate_AllInternalCommits_ReturnsEmpty(t *testing.T) {
 
 func TestGenerate_LLMError_ReturnsWarning(t *testing.T) {
 	git := &mockGitForRelease{}
-	llm := &mockAreaLLM{err: fmt.Errorf("LLM unavailable")}
+	llm := &mockFreeformLLM{err: fmt.Errorf("LLM unavailable")}
 	chunker := &mockLogChunker{}
 
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
 	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-	}
 
-	commits := "abc feat(core): add new feature"
+	commits := "abc feat: add new feature"
 	_, warnings, _, err := svc.Generate(commits)
 	if err == nil {
 		t.Error("expected error from LLM failure")
@@ -269,29 +194,21 @@ func TestGenerate_LLMError_ReturnsWarning(t *testing.T) {
 
 func TestFilterForChangelog_ExcludesDocsAndInternal(t *testing.T) {
 	cfg := &domain.ProjectConfig{
-		Excluded: []string{"docs", "scripts"},
+		Excluded: []string{"docs/", "scripts/"},
 	}
-	commits := "abc1234 feat(core): add feature\ndef5678 docs: update readme\nghi9012 chore(scripts): update build\njkl3456 fix(core): fix bug"
+	commits := "abc1234 feat: add feature\ndef5678 docs: update readme\nghi9012 chore(scripts): update build\njkl3456 fix: fix bug"
 	groups := filterForChangelog(commits, cfg)
-	// core should have both feat and fix
-	if len(groups["core"]) != 2 {
-		t.Errorf("core area: want 2 commits, got %d", len(groups["core"]))
+	// Should have feat and fix (no scope)
+	if len(groups[""]) != 2 {
+		t.Errorf("no-scope group: want 2 commits (feat + fix), got %d", len(groups[""]))
 	}
 	// chore(scripts) has type "chore" (skipType) so filtered by skipTypes
 	if _, ok := groups["scripts"]; ok {
 		t.Error("scripts scope should be excluded (skipType chore)")
 	}
-	// docs: update readme has no scope and type "docs" (not skipType) so it passes
-	if len(groups[""]) != 1 {
-		t.Errorf("no-scope group: want 1 commit, got %d", len(groups[""]))
-	}
-	// Total non-excluded items: feat(core) + fix(core) + docs(empty scope) = 3
-	total := 0
-	for _, items := range groups {
-		total += len(items)
-	}
-	if total != 3 {
-		t.Errorf("expected 3 user-facing commits after filtering, got %d", total)
+	// docs: update readme has type "docs" (not skipType) so it passes
+	if len(groups[""]) < 1 {
+		t.Errorf("docs commit should pass filtering")
 	}
 }
 
@@ -321,278 +238,120 @@ func TestFilterForChangelog_BreakingNotFiltered(t *testing.T) {
 }
 
 // --- groupByArea tests ---
+// DEPRECATED: groupByArea removed in Phase 2 - LLM freeform categorization replaces it
+// Tests removed along with the functions
 
-func TestGroupByArea_SortedMapping(t *testing.T) {
-	cfg := &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"tui":    {"internal/ui"},
-			"core":   {"internal/core"},
-			"deploy": {"internal/deploy"},
-		},
-	}
-	// Note: groupByArea receives pre-filtered groups from FilterAndGroupCommits
-	// Keyed by conventional-commit scope (which is the area name from the area mapping)
-	groups := map[string][]string{
-		"core":   {"feat(core): add feature", "fix(core): fix bug"},
-		"tui":    {"feat(tui): add screen"},
-		"deploy": {"chore(deploy): update config"},
-	}
+// --- Generate freeform tests ---
 
-	areaGroups, nameMap := groupByArea(groups, cfg)
-
-	// Areas should be sorted: core=group_1, deploy=group_2, tui=group_3
-	if len(areaGroups) != 3 {
-		t.Errorf("expected 3 area groups, got %d", len(areaGroups))
-	}
-	// areaGroups keys should be group_N
-	for key := range areaGroups {
-		if !strings.HasPrefix(key, "group_") {
-			t.Errorf("expected group_N key, got %q", key)
-		}
-	}
-	// nameMap should map group_N back to area names
-	if len(nameMap) != 3 {
-		t.Errorf("expected 3 name mappings, got %d", len(nameMap))
-	}
-	// Verify reverse mapping: group_1 → core (alphabetically first)
-	sortedAreas := []string{"core", "deploy", "tui"}
-	for i, area := range sortedAreas {
-		groupKey := fmt.Sprintf("group_%d", i+1)
-		if nameMap[groupKey] != area {
-			t.Errorf("nameMap[%q] = %q, want %q", groupKey, nameMap[groupKey], area)
-		}
-	}
-}
-
-func TestGroupByArea_EmptyAreas(t *testing.T) {
-	cfg := &domain.ProjectConfig{
-		Areas: map[string][]string{},
-	}
-	groups := map[string][]string{
-		"": {"feat: add feature"},
-	}
-	areaGroups, nameMap := groupByArea(groups, cfg)
-	if len(areaGroups) != 0 {
-		t.Errorf("expected 0 area groups with empty areas, got %d", len(areaGroups))
-	}
-	if len(nameMap) != 0 {
-		t.Errorf("expected 0 name mappings with empty areas, got %d", len(nameMap))
-	}
-}
-
-func TestGroupByArea_NilAreas(t *testing.T) {
-	cfg := &domain.ProjectConfig{}
-	groups := map[string][]string{
-		"": {"feat: add feature"},
-	}
-	areaGroups, _ := groupByArea(groups, cfg)
-	if len(areaGroups) != 0 {
-		t.Errorf("expected 0 area groups with nil areas, got %d", len(areaGroups))
-	}
-}
-
-// --- remapGroupKeys tests ---
-
-func TestRemapGroupKeys_GroupToArea(t *testing.T) {
-	ch := domain.ChangelogByArea{
-		"group_1": []string{"add feature", "fix bug"},
-		"group_2": []string{"update screen"},
-	}
-	nameMap := map[string]string{
-		"group_1": "core",
-		"group_2": "tui",
-	}
-
-	result := remapGroupKeys(ch, nameMap)
-
-	if len(result) != 2 {
-		t.Fatalf("expected 2 areas, got %d", len(result))
-	}
-	if len(result["core"]) != 2 {
-		t.Errorf("expected 2 items in core, got %d", len(result["core"]))
-	}
-	if len(result["tui"]) != 1 {
-		t.Errorf("expected 1 item in tui, got %d", len(result["tui"]))
-	}
-	if _, ok := result["group_1"]; ok {
-		t.Error("group_1 key should not exist in result")
-	}
-}
-
-func TestRemapGroupKeys_EmptyInput(t *testing.T) {
-	ch := domain.ChangelogByArea{}
-	nameMap := map[string]string{}
-
-	result := remapGroupKeys(ch, nameMap)
-	if len(result) != 0 {
-		t.Errorf("expected empty result, got %d areas", len(result))
-	}
-}
-
-// --- Generate routing tests ---
-
-func TestGenerate_NilAreas_ReturnsError(t *testing.T) {
+func TestGenerate_Freeform_ReturnsLLMCategorizedChangelog(t *testing.T) {
 	git := &mockGitForRelease{}
-	llm := &mockAreaLLM{
-		result: domain.ChangelogByArea{"core": []string{"add feature"}},
+	llm := &mockFreeformLLM{
+		result: domain.ChangelogByArea{
+			"Authentication": {"Added login flow with JWT tokens"},
+			"API":            {"Exposed new webhook endpoints"},
+		},
 	}
 	chunker := &mockLogChunker{}
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
 	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = nil
 
-	commits := "abc feat: add feature"
-	_, _, _, err := svc.Generate(commits)
-	if err == nil {
-		t.Error("expected error when areas not configured")
-	}
-	if !strings.Contains(err.Error(), "areas") {
-		t.Errorf("error should mention areas, got: %v", err)
-	}
-}
-
-func TestGenerate_WithAreas_RoutesToByArea(t *testing.T) {
-	git := &mockGitForRelease{}
-	llm := &mockAreaLLM{
-		result: domain.ChangelogByArea{"core": []string{"add feature"}},
-	}
-	chunker := &mockLogChunker{}
-	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
-	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-	}
-
-	commits := "abc feat(core): add feature"
-	_, _, _, err := svc.Generate(commits)
+	commits := "abc feat: add login\nbcd feat(api): add webhooks"
+	changelog, warnings, isBg, err := svc.Generate(commits)
 	if err != nil {
 		t.Fatalf("Generate() error: %v", err)
 	}
-	if llm.called == "" {
-		t.Error("GenerateChangelogByArea should have been called when areas is configured")
+	if isBg {
+		t.Error("Generate should return isBg=false")
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+	if !llm.freeformCalled {
+		t.Error("GenerateChangelogGrouped should have been called in freeform mode")
+	}
+	if llm.mode != "freeform" {
+		t.Errorf("mode = %q, want %q", llm.mode, "freeform")
+	}
+	// Verify changelog contains LLM-invented category names
+	if !strings.Contains(changelog, "## Authentication") {
+		t.Errorf("changelog should contain LLM category 'Authentication', got:\n%s", changelog)
+	}
+	if !strings.Contains(changelog, "## API") {
+		t.Errorf("changelog should contain LLM category 'API', got:\n%s", changelog)
 	}
 }
 
-// --- nameMap routing tests ---
-
-// mockNameMapLLM tracks that GenerateChangelogByArea receives the nameMap
-type mockNameMapLLM struct {
-	byAreaResult  domain.ChangelogByArea
-	byAreaErr     error
-	byAreaCalled  bool
-	byAreaInput   string
-	byAreaNameMap map[string]string
-}
-
-func (m *mockNameMapLLM) GenerateChunkMessage(chunk domain.DiffChunk) (string, error) { return "", nil }
-func (m *mockNameMapLLM) GenerateCommitSynthesis(combinedChunk domain.DiffChunk, fileMessages []string) (string, error) {
-	return "", nil
-}
-func (m *mockNameMapLLM) InterpretGitOp(op, instruction string, ctx map[string]string) (map[string]string, error) {
-	return nil, nil
-}
-func (m *mockNameMapLLM) SetRetryContext(msg string) {}
-func (m *mockNameMapLLM) ClearRetryContext()         {}
-func (m *mockNameMapLLM) IsAvailable() bool          { return true }
-func (m *mockNameMapLLM) VerifySecrets(diff string, findings []domain.SecretDetection) (bool, error) {
-	return false, nil
-}
-func (m *mockNameMapLLM) AuditBinaryContent(filename, content string) (bool, error) {
-	return false, nil
-}
-func (m *mockNameMapLLM) GenerateChangelogByArea(formattedGroups string, nameMap map[string]string, customMessage string) (domain.ChangelogByArea, error) {
-	m.byAreaCalled = true
-	m.byAreaInput = formattedGroups
-	m.byAreaNameMap = nameMap
-	if m.byAreaErr != nil {
-		return nil, m.byAreaErr
-	}
-	return m.byAreaResult, nil
-}
-func (m *mockNameMapLLM) GenerateChangelogGrouped(formattedGroups string, nameMap map[string]string, customMessage string, mode string) (domain.ChangelogByArea, error) {
-	return m.GenerateChangelogByArea(formattedGroups, nameMap, customMessage)
-}
-func (m *mockNameMapLLM) RegenerateMessage(prev []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
-	return nil, nil
-}
-func (m *mockNameMapLLM) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) { return nil, nil }
-func (m *mockNameMapLLM) ClassifyBinary(prompt string) (string, error) {
-	return "fix", nil
-}
-
-func TestGenerate_WithAreas_PassesNameMap(t *testing.T) {
+func TestGenerate_Fallback_WhenNoBaseBranch(t *testing.T) {
 	git := &mockGitForRelease{}
-	llm := &mockNameMapLLM{
-		byAreaResult: domain.ChangelogByArea{"core": []string{"Added feature"}},
-	}
-	chunker := &mockLogChunker{}
-	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
-	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-	}
-
-	commits := "abc feat(core): add feature"
-	_, _, _, err := svc.Generate(commits)
-	if err != nil {
-		t.Fatalf("Generate() error: %v", err)
-	}
-	if !llm.byAreaCalled {
-		t.Fatal("GenerateChangelogByArea should have been called")
-	}
-	// Verify nameMap has the group_N → area mapping
-	if len(llm.byAreaNameMap) == 0 {
-		t.Error("nameMap should not be empty when areas are configured")
-	}
-	// With one area "core", nameMap should map group_1 → core
-	if llm.byAreaNameMap["group_1"] != "core" {
-		t.Errorf("nameMap[group_1] = %q, want %q", llm.byAreaNameMap["group_1"], "core")
-	}
-	// Verify the formatted groups input uses group_N keys, not area names
-	if strings.Contains(llm.byAreaInput, "core:") && !strings.Contains(llm.byAreaInput, "group_1:") {
-		t.Error("formatted groups should use group_N keys, not area names like 'core'")
-	}
-	if !strings.Contains(llm.byAreaInput, "group_1:") {
-		t.Errorf("formatted groups should contain 'group_1:', got:\n%s", llm.byAreaInput)
-	}
-}
-
-func TestGenerate_WithAreas_Remapping(t *testing.T) {
-	// Test that group_N keys in the LLM response are remapped to area names
-	git := &mockGitForRelease{}
-	// LLM returns group_N keys — simulating real LLM behavior
-	llm := &mockNameMapLLM{
-		byAreaResult: domain.ChangelogByArea{
-			"group_1": []string{"Added semantic diff analysis"},
-			"group_2": []string{"Fixed webhook auth bypass"},
+	llm := &mockFreeformLLM{
+		result: domain.ChangelogByArea{
+			"Features": {"Added new capability"},
 		},
 	}
 	chunker := &mockLogChunker{}
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
 	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core":     {"internal/core"},
-			"security": {"internal/auth"},
-		},
-	}
+	// No BaseBranch, no Areas → freeform fallback
 
-	commits := "abc feat(core): add feature\ndef fix(security): fix bug"
+	commits := "abc feat: add capability"
 	changelog, _, _, err := svc.Generate(commits)
 	if err != nil {
 		t.Fatalf("Generate() error: %v", err)
 	}
-	// Verify remapping happened — should contain area names, not group_N
-	if !strings.Contains(changelog, "## Core") && !strings.Contains(changelog, "## Security") {
-		t.Errorf("changelog should contain area section headers (Core, Security), got:\n%s", changelog)
+	if !llm.freeformCalled {
+		t.Error("GenerateChangelogGrouped should be called in freeform fallback")
 	}
-	if strings.Contains(changelog, "group_1") || strings.Contains(changelog, "group_2") {
-		t.Errorf("group_N keys should be remapped to area names, got:\n%s", changelog)
+	if !strings.Contains(changelog, "## Features") {
+		t.Errorf("changelog should contain category header, got:\n%s", changelog)
 	}
+}
+
+// --- mockFreeformLLM for freeform generation tests ---
+
+type mockFreeformLLM struct {
+	result        domain.ChangelogByArea
+	err           error
+	freeformCalled bool
+	input         string
+	nameMap       map[string]string
+	customMessage string
+	mode          string
+}
+
+func (m *mockFreeformLLM) GenerateChunkMessage(chunk domain.DiffChunk) (string, error) { return "", nil }
+func (m *mockFreeformLLM) GenerateCommitSynthesis(combinedChunk domain.DiffChunk, fileMessages []string) (string, error) {
+	return "", nil
+}
+func (m *mockFreeformLLM) InterpretGitOp(op, instruction string, ctx map[string]string) (map[string]string, error) {
+	return nil, nil
+}
+func (m *mockFreeformLLM) SetRetryContext(msg string) {}
+func (m *mockFreeformLLM) ClearRetryContext()         {}
+func (m *mockFreeformLLM) IsAvailable() bool          { return true }
+func (m *mockFreeformLLM) VerifySecrets(diff string, findings []domain.SecretDetection) (bool, error) {
+	return false, nil
+}
+func (m *mockFreeformLLM) AuditBinaryContent(filename, content string) (bool, error) { return false, nil }
+func (m *mockFreeformLLM) GenerateChangelogByArea(formattedGroups string, nameMap map[string]string, customMessage string) (domain.ChangelogByArea, error) {
+	return m.GenerateChangelogGrouped(formattedGroups, nameMap, customMessage, "freeform")
+}
+func (m *mockFreeformLLM) GenerateChangelogGrouped(formattedGroups string, nameMap map[string]string, customMessage string, mode string) (domain.ChangelogByArea, error) {
+	m.freeformCalled = true
+	m.input = formattedGroups
+	m.nameMap = nameMap
+	m.customMessage = customMessage
+	m.mode = mode
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.result, nil
+}
+func (m *mockFreeformLLM) RegenerateMessage(prev []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
+	return nil, nil
+}
+func (m *mockFreeformLLM) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) { return nil, nil }
+func (m *mockFreeformLLM) ClassifyBinary(prompt string) (string, error) {
+	return "fix", nil
 }
 
 // --- Chunking support tests ---
@@ -686,35 +445,8 @@ func TestGenerateChangelogGrouped_StackMode(t *testing.T) {
 }
 
 func TestGenerateChangelogGrouped_AreaMode(t *testing.T) {
-	// Test that GenerateChangelogGrouped is called with mode="area"
-	// when areas are configured but no base branch (traditional path).
-	git := &mockGitForRelease{}
-	llm := &mockGroupedLLM{
-		result: domain.ChangelogByArea{
-			"core": []string{"Added feature"},
-		},
-	}
-	chunker := &mockLogChunker{}
-	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
-	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-		// BaseBranch is empty → areas path
-	}
-
-	commits := "abc feat(core): add feature"
-	_, _, _, err := svc.Generate(commits)
-	if err != nil {
-		t.Fatalf("Generate() error: %v", err)
-	}
-	if !llm.groupedCalled {
-		t.Error("GenerateChangelogGrouped should have been called for area path")
-	}
-	if llm.mode != "area" {
-		t.Errorf("GenerateChangelogGrouped mode = %q, want %q", llm.mode, "area")
-	}
+	// DEPRECATED: Area mode removed in Phase 2 - now uses freeform mode
+	t.Skip("Area mode deprecated - freeform categorization is now default")
 }
 
 func TestGenerateWithStacks_UnspecifiedGroupFallback(t *testing.T) {

--- a/internal/workflow/release_service_test.go
+++ b/internal/workflow/release_service_test.go
@@ -393,12 +393,10 @@ func TestReleaseService_Generate(t *testing.T) {
 	chunker := &mockLogChunker{}
 	svc := newReleaseSvcWithChunker(t, git, llm, chunker)
 	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
+		Description: "Test project",
 	}
 
-	commits := "feat(core): add feature\nfeat(core): another feature"
+	commits := "feat: add feature\nfeat: another feature"
 
 	changelog, lines, _, err := svc.Generate(commits)
 	if err != nil {
@@ -420,9 +418,7 @@ func TestReleaseService_Generate_EmptyInput(t *testing.T) {
 	}
 	svc := newReleaseSvcWithChunker(t, git, llm, chunker)
 	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
+		Description: "Test project",
 	}
 
 	_, _, _, err := svc.Generate("")
@@ -438,9 +434,7 @@ func TestReleaseService_Generate_AllInternalReturnsEmpty(t *testing.T) {
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(dir, "release.log"))
 	svc := NewReleaseService(git, llm, nil, cfg, nil, nil)
 	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
+		Description: "Test project",
 	}
 
 	_, _, _, err := svc.Generate("abc test: add tests\ndef chore: bump deps")


### PR DESCRIPTION
## Motivation

PR 1 removed `Areas` from the domain model. This PR updates the **workflow layer** to work without predefined areas — the LLM now receives flat commits and generates its own categories.

## Changes (PR 2 of 3)

### Workflow — `internal/workflow/`
- **commit.go**: Removed `resolveChunkScopes()` — chunks no longer receive area-based scope injection
- **release_generate.go**: Replaced `generateWithAreas()` with `generateFreeform()`. Removed `groupByArea()` and `remapGroupKeys()`. `Generate()` falls back to freeform when neither `BaseBranch` nor `Areas` are present
- **release.go**: No changes needed (already description-only)

### Prompts
- **changelog_areas.md**: Deleted — obsolete rigid prompt
- **changelog.md**: Created — sends flat commits, LLM invents categories, returns `{"Category Name": ["bullet"]}`

### Cleanup (compiler-enforced)
- Removed `Areas` from test configs, adapter returns, handlers

### Tests
- Removed: `groupByArea` tests
- Added: `generateFreeform()` with mock LLM, fallback tests

## Impact
- 10 files modified, 1 deleted, 1 created
- All workflow package tests pass

## Dependency
- Requires PR 1 (#121) as base