### PR TITLE
feat: LLM freeform categories — remove predefined Areas

### DIFF
--- a/.git-courer/branches/llm-freeform-categories-pr1/commits.json
+++ b/.git-courer/branches/llm-freeform-categories-pr1/commits.json
@@ -1,0 +1,8 @@
+[
+  {
+    "sha": "714544f28deb0a1351d9202a54c82f982dd3d7d0",
+    "message": "fix: remove deprecated areas field from project configuration\n\nWHY\nThe areas field in ProjectConfig was redundant and complicated the configuration logic, as path-based classification is now handled via PathTypes and Excluded rules. It required manual normalization and complex path matching during initialization and serialization.\n\nWHAT\n* Removed the areas field from ProjectConfig struct and its JSON mapping.\n* Deleted logic for initializing, writing, and resolving the areas map.\n* Simplified LoadProjectConfig to ignore legacy areas.\n* Updated FormatScopeContext to only return the project description.",
+    "author": "blak0p",
+    "date": "2026-06-06T12:22:17Z"
+  }
+]

--- a/.git-courer/branches/llm-freeform-categories-pr2/commits.json
+++ b/.git-courer/branches/llm-freeform-categories-pr2/commits.json
@@ -10,5 +10,11 @@
     "message": "fix: remove deprecated areas field from project configuration",
     "author": "blak0p",
     "date": "2026-06-06"
+  },
+  {
+    "sha": "7332f4a32253d5e51755948d1347479d9edac8f3",
+    "message": "feat!: refactor changelog generation to use freeform LLM categorization\n\nWHY\nChangelog generation was strictly tied to predefined project areas, preventing flexible, context-aware categorization when areas were not configured and causing unnecessary overhead during description retrieval and scope resolution.\n\nWHAT\n* Replaced area-based grouping and name mapping with a freeform LLM-driven approach using `generateFreeform`.\n* Removed dependency on `projectCfg.Areas` for changelog generation and removed redundant map initialization in project config.\n* Deleted redundant chunk scope resolution logic in `CommitService`.\n* Simplified `OpenAIStandardAdapter` by removing project area retrieval during description construction.\n* Updated `ReleaseService` to use freeform grouping as the default fallback.\n* Updated documentation and changelog to reflect structural changes.",
+    "author": "blak0p",
+    "date": "2026-06-06T12:37:21Z"
   }
 ]

--- a/.git-courer/branches/llm-freeform-categories-pr2/commits.json
+++ b/.git-courer/branches/llm-freeform-categories-pr2/commits.json
@@ -1,0 +1,14 @@
+[
+  {
+    "sha": "036685887d36694c88df8673e22f22ab2af3fbc8",
+    "message": "fix: remove deprecated areas field from project configuration",
+    "author": "blak0p",
+    "date": "2026-06-06"
+  },
+  {
+    "sha": "714544f28deb0a1351d9202a54c82f982dd3d7d0",
+    "message": "fix: remove deprecated areas field from project configuration",
+    "author": "blak0p",
+    "date": "2026-06-06"
+  }
+]

--- a/.git-courer/branches/llm-freeform-categories-pr3/commits.json
+++ b/.git-courer/branches/llm-freeform-categories-pr3/commits.json
@@ -1,0 +1,26 @@
+[
+  {
+    "sha": "f6a063dd771cbf9c0d60c0f7047a92a573be426c",
+    "message": "feat!: refactor changelog generation to use freeform LLM categorization",
+    "author": "blak0p",
+    "date": "2026-06-06"
+  },
+  {
+    "sha": "7332f4a32253d5e51755948d1347479d9edac8f3",
+    "message": "feat!: refactor changelog generation to use freeform LLM categorization",
+    "author": "blak0p",
+    "date": "2026-06-06"
+  },
+  {
+    "sha": "036685887d36694c88df8673e22f22ab2af3fbc8",
+    "message": "fix: remove deprecated areas field from project configuration",
+    "author": "blak0p",
+    "date": "2026-06-06"
+  },
+  {
+    "sha": "714544f28deb0a1351d9202a54c82f982dd3d7d0",
+    "message": "fix: remove deprecated areas field from project configuration",
+    "author": "blak0p",
+    "date": "2026-06-06"
+  }
+]

--- a/.git-courer/branches/llm-freeform-categories-pr3/commits.json
+++ b/.git-courer/branches/llm-freeform-categories-pr3/commits.json
@@ -34,5 +34,11 @@
     "message": "fix: remove deprecated areas field from project configuration",
     "author": "blak0p",
     "date": "2026-06-06"
+  },
+  {
+    "sha": "95ca0a5724f9e1ee159e08edd15e34077dc19250",
+    "message": "feat: unify changelog prompt logic and support freeform mode\n\nWHY\nThe changelog generation was restricted to specific modes and relied on an outdated prompt template that did not support freeform user instructions. Additionally, the removal of changelog_areas.md caused template retrieval errors.\n\nWHAT\n* Updated GenerateChangelogGrouped to support 'freeform' mode.\n* Switched prompt template from 'changelog_areas' to 'changelog' to unify logic.\n* Added GetChangelog to retrieve the standard changelog template.\n* Updated GetChangelogAreas to fallback to the changelog template.",
+    "author": "blak0p",
+    "date": "2026-06-07T18:25:42Z"
   }
 ]

--- a/.git-courer/branches/llm-freeform-categories-pr3/commits.json
+++ b/.git-courer/branches/llm-freeform-categories-pr3/commits.json
@@ -22,5 +22,11 @@
     "message": "fix: remove deprecated areas field from project configuration",
     "author": "blak0p",
     "date": "2026-06-06"
+  },
+  {
+    "sha": "506c3da4ffc74cc06d4f2d52e032bc759844801c",
+    "message": "feat: replace init command with TUI wizard and simplify configuration\n\nWHY\nThe existing initialization process relied on manual terminal input and a complex project areas configuration (mapping names to path prefixes) that was error-prone, difficult to maintain, and insufficient for verifying changes. Additionally, the lack of a defined test command limited the ability to automate validation during git operations.\n\nWHAT\n* Replaced the CLI-based `runInitCmd` with a TUI-driven `runTUIInit` using an interactive screen flow.\n* Removed the multi-step project areas mapping logic and associated data structures.\n* Added a `test_command` field to `ProjectConfig` to allow users to define a single command for executing test suites.\n* Updated the initialization wizard to prompt for a test command instead of area definitions.\n* Refactored configuration saving and UI components to handle the new single-string test command input.\n* Fixed a potential inconsistent state in MCP by returning a zero-value `ProjectConfig` on configuration load errors.",
+    "author": "blak0p",
+    "date": "2026-06-06T16:47:09Z"
   }
 ]

--- a/.git-courer/branches/llm-freeform-categories-pr3/commits.json
+++ b/.git-courer/branches/llm-freeform-categories-pr3/commits.json
@@ -1,5 +1,17 @@
 [
   {
+    "sha": "33888fcd4050dda183a7c757566be6cb5fbf6e95",
+    "message": "feat: replace init command with TUI wizard and simplify configuration",
+    "author": "blak0p",
+    "date": "2026-06-06"
+  },
+  {
+    "sha": "506c3da4ffc74cc06d4f2d52e032bc759844801c",
+    "message": "feat: replace init command with TUI wizard and simplify configuration",
+    "author": "blak0p",
+    "date": "2026-06-06"
+  },
+  {
     "sha": "f6a063dd771cbf9c0d60c0f7047a92a573be426c",
     "message": "feat!: refactor changelog generation to use freeform LLM categorization",
     "author": "blak0p",
@@ -22,11 +34,5 @@
     "message": "fix: remove deprecated areas field from project configuration",
     "author": "blak0p",
     "date": "2026-06-06"
-  },
-  {
-    "sha": "506c3da4ffc74cc06d4f2d52e032bc759844801c",
-    "message": "feat: replace init command with TUI wizard and simplify configuration\n\nWHY\nThe existing initialization process relied on manual terminal input and a complex project areas configuration (mapping names to path prefixes) that was error-prone, difficult to maintain, and insufficient for verifying changes. Additionally, the lack of a defined test command limited the ability to automate validation during git operations.\n\nWHAT\n* Replaced the CLI-based `runInitCmd` with a TUI-driven `runTUIInit` using an interactive screen flow.\n* Removed the multi-step project areas mapping logic and associated data structures.\n* Added a `test_command` field to `ProjectConfig` to allow users to define a single command for executing test suites.\n* Updated the initialization wizard to prompt for a test command instead of area definitions.\n* Refactored configuration saving and UI components to handle the new single-string test command input.\n* Fixed a potential inconsistent state in MCP by returning a zero-value `ProjectConfig` on configuration load errors.",
-    "author": "blak0p",
-    "date": "2026-06-06T16:47:09Z"
   }
 ]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
-	"sort"
 	"strings"
 	"syscall"
 
@@ -21,6 +19,7 @@ import (
 	"github.com/blak0p/git-courer/internal/infra/chunkers"
 	"github.com/blak0p/git-courer/internal/installer"
 	"github.com/blak0p/git-courer/tui"
+	"github.com/blak0p/git-courer/tui/screens"
 )
 
 // isTTY checks if running in an interactive terminal
@@ -69,7 +68,7 @@ func main() {
 		runUpdate()
 		return
 	case "init":
-		runInitCmd()
+		runTUIInit()
 		return
 	case "release":
 		runRelease(os.Args[2:])
@@ -232,136 +231,13 @@ func runMCPSetup() {
 	}
 }
 
-func runInitCmd() {
-	fmt.Println("Scanning repository for programming languages...")
-	exts := make(map[string]bool)
-	_ = filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() {
-			return nil
-		}
-		// Skip hidden paths
-		if strings.HasPrefix(info.Name(), ".") && info.Name() != ".env" {
-			return nil
-		}
-		parts := strings.Split(path, string(os.PathSeparator))
-		for _, p := range parts {
-			if strings.HasPrefix(p, ".") && p != "." && p != ".." && p != ".env" {
-				return nil
-			}
-		}
-		ext := filepath.Ext(path)
-		if ext != "" {
-			exts[ext] = true
-		}
-		return nil
-	})
-
-	catalog := chunkers.NewLanguageCatalog()
-	langMap := make(map[string]bool)
-	var displayLangs []string
-	var downloadLangs []string
-	for ext := range exts {
-		if entry, ok := catalog.ExtensionToLanguage(ext); ok {
-			if !langMap[entry.Name] {
-				langMap[entry.Name] = true
-				displayLangs = append(displayLangs, entry.DomainName)
-				downloadLangs = append(downloadLangs, entry.Name)
-			}
-		}
-	}
-	sort.Strings(displayLangs)
-	sort.Strings(downloadLangs)
-
-	if len(displayLangs) > 0 {
-		fmt.Printf("Detected languages: %s\n", strings.Join(displayLangs, ", "))
-		fmt.Println("Ensuring/downloading Tree-Sitter grammars...")
-		if err := chunkers.EnsureLanguages(downloadLangs); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to ensure languages: %v\n", err)
-		} else {
-			fmt.Println("✓ Tree-Sitter grammars are ready.")
-		}
-	} else {
-		fmt.Println("No programming languages detected.")
-	}
-
-	// Detect base branch
+// runTUIInit launches the TUI init wizard for project configuration.
+func runTUIInit() {
 	gitAdapter := gitadapter.New(".")
-	detectedBaseBranch := domain.DetectBaseBranch(gitAdapter)
-
-	var baseBranch string
-	if detectedBaseBranch != "" {
-		fmt.Printf("\nDetected base branch: %s\n", detectedBaseBranch)
-		fmt.Print("Press ENTER to confirm, or type a different branch (leave empty to skip): ")
-		reader := bufio.NewReader(os.Stdin)
-		input, _ := reader.ReadString('\n')
-		input = strings.TrimSpace(input)
-		if input == "" {
-			baseBranch = detectedBaseBranch
-		} else {
-			baseBranch = input
-		}
-	} else {
-		fmt.Print("\nNo default branch detected. Enter your base branch (e.g., main, develop) or press ENTER to skip: ")
-		reader := bufio.NewReader(os.Stdin)
-		input, _ := reader.ReadString('\n')
-		baseBranch = strings.TrimSpace(input)
-	}
-
-	dir := filepath.Join(".", ".git-courer")
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating .git-courer directory: %v\n", err)
+	if err := screens.RunInitScreen(".", gitAdapter); err != nil {
+		fmt.Fprintf(os.Stderr, "Init error: %v\n", err)
 		os.Exit(1)
 	}
-
-	// Build config JSON
-	baseBranchJSON := ""
-	if baseBranch != "" {
-		baseBranchJSON = fmt.Sprintf(",\n  \"base_branch\": %q", baseBranch)
-	}
-
-	template := fmt.Sprintf(`{
-  "description": "Short description of the project (used for commit context)",
-  "areas": {
-    "core": ["internal/core/"],
-    "cli": ["cmd/", "internal/delivery/cli/"],
-    "tui": ["tui/"]
-  },%s,
-  "test_command": "go test ./...",
-  "excluded": ["vendor/", "*.pb.go", "*_test.go", ".git-courer/"]
-}`, baseBranchJSON)
-
-	configPath := filepath.Join(dir, "config.json")
-	examplePath := filepath.Join(dir, "config.json.example")
-
-	// Write example file (always)
-	if err := os.WriteFile(examplePath, []byte(template), 0644); err != nil {
-		fmt.Fprintf(os.Stderr, "Error writing example configuration: %v\n", err)
-		os.Exit(1)
-	}
-
-	// If no config exists yet, write the actual config too
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		if err := os.WriteFile(configPath, []byte(template), 0644); err != nil {
-			fmt.Fprintf(os.Stderr, "Error writing configuration: %v\n", err)
-			os.Exit(1)
-		}
-		fmt.Println("")
-		fmt.Printf("✓ Configuration saved to .git-courer/config.json (base branch: %s)\n", func() string {
-			if baseBranch != "" {
-				return baseBranch
-			}
-			return "auto-detect"
-		}())
-	} else {
-		fmt.Println("")
-		fmt.Println("Created template configuration at .git-courer/config.json.example")
-		fmt.Println("")
-		fmt.Println("To update your project configuration, run:")
-		fmt.Println("  cp .git-courer/config.json.example .git-courer/config.json")
-	}
-
-	fmt.Println("")
-	fmt.Println("Then, edit .git-courer/config.json to match your project's structure.")
 }
 
 func runTUI() {
@@ -372,7 +248,6 @@ func runTUI() {
 		fmt.Println("")
 		fmt.Println("Usage:")
 		fmt.Println("  git-courer           # Launch TUI (requires terminal)")
-		fmt.Println("  git-courer init        # Initialize project configuration")
 		fmt.Println("  git-courer mcp      # Run MCP server")
 		fmt.Println("  git-courer mcp setup # Configure MCP clients")
 		fmt.Println("  git-courer update    # Check for updates")

--- a/internal/adapters/llm/openai_standard/adapter_project.go
+++ b/internal/adapters/llm/openai_standard/adapter_project.go
@@ -23,11 +23,7 @@ func (a *OpenAIStandardAdapter) ProjectInit(repoRoot string) (*domain.ProjectCon
 	if err != nil {
 		return nil, fmt.Errorf("project description: %w", err)
 	}
-	areas, err := a.getProjectAreas(repoRoot)
-	if err != nil {
-		return nil, fmt.Errorf("project areas: %w", err)
-	}
-	return &domain.ProjectConfig{Description: description, Areas: areas}, nil
+	return &domain.ProjectConfig{Description: description}, nil
 }
 
 func (a *OpenAIStandardAdapter) getProjectDescription(repoRoot string) (string, error) {

--- a/internal/adapters/llm/openai_standard/adapter_release.go
+++ b/internal/adapters/llm/openai_standard/adapter_release.go
@@ -54,15 +54,13 @@ func (a *OpenAIStandardAdapter) GenerateChangelogByArea(formattedGroups string, 
 }
 
 // GenerateChangelogGrouped translates grouped commits into user-facing release notes.
-// mode is "area" or "stack". For area mode, uses changelog_areas prompt and remaps group_N to area names.
-// For stack mode, uses changelog_areas prompt (same format) but labels represent inferred stack labels.
+// mode is "area", "stack", or "freeform". All modes use the same changelog prompt template.
 // formattedGroups uses group_N keys — the LLM never sees real labels. nameMap remaps them.
 // customMessage is optional user instructions injected into the prompt.
 func (a *OpenAIStandardAdapter) GenerateChangelogGrouped(formattedGroups string, nameMap map[string]string, customMessage string, mode string) (domain.ChangelogByArea, error) {
-	// Both modes use the same changelog_areas prompt template.
+	// All modes use the same changelog prompt template.
 	// The prompt instructs the LLM to translate grouped commits into release notes.
-	// Stack mode simply uses the same structure with stack-identified groups.
-	tmpl, err := prompts.Get("changelog_areas")
+	tmpl, err := prompts.Get("changelog")
 	if err != nil {
 		return nil, fmt.Errorf("prompt not found: %w", err)
 	}

--- a/internal/adapters/llm/openai_standard/adapter_test.go
+++ b/internal/adapters/llm/openai_standard/adapter_test.go
@@ -1676,55 +1676,42 @@ func TestAdapter_OllamaOptions_NoNumCtxWhenNotSet(t *testing.T) {
 
 // --- GenerateChangelogByArea with nameMap ---
 
-func TestAdapter_GenerateChangelogByArea_WithNameMap(t *testing.T) {
+func TestAdapter_GenerateChangelogGrouped_FreeformMode(t *testing.T) {
+	// Test freeform mode: LLM invents its own category names, no remapping
 	expectedResult := domain.ChangelogByArea{
-		"group_1": []string{"Added semantic diff analysis"},
-		"group_2": []string{"Fixed auth token validation"},
+		"Authentication": []string{"Added login flow with JWT tokens"},
+		"API":            []string{"Exposed new webhook endpoints"},
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/chat/completions" {
-			t.Errorf("expected /v1/chat/completions, got %s", r.URL.Path)
-		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(chatCompletionResponse(mockJSONResponse(t, expectedResult)))
 	}))
 	defer server.Close()
 
 	adapter := newTestAdapter(server)
-	nameMap := map[string]string{
-		"group_1": "core",
-		"group_2": "security",
-	}
-
-	ch, err := adapter.GenerateChangelogByArea("group_1:\n- feat(core): add feature\ngroup_2:\n- fix(security): fix bug", nameMap, "")
+	// In freeform mode, nameMap is nil — LLM invents category names
+	ch, err := adapter.GenerateChangelogGrouped("general:\n- feat: add login\n- feat(api): add webhooks", nil, "", "freeform")
 	if err != nil {
-		t.Fatalf("GenerateChangelogByArea failed: %v", err)
+		t.Fatalf("GenerateChangelogGrouped failed: %v", err)
 	}
 
-	// Verify remapping: group_1 → core, group_2 → security
+	// Verify LLM-invented categories are present
 	if len(ch) != 2 {
-		t.Fatalf("expected 2 areas after remapping, got %d", len(ch))
+		t.Fatalf("expected 2 categories, got %d: %v", len(ch), ch)
 	}
-	if items, ok := ch["core"]; !ok || len(items) != 1 || items[0] != "Added semantic diff analysis" {
-		t.Errorf("core area: got %v", ch["core"])
+	if items, ok := ch["Authentication"]; !ok || len(items) != 1 {
+		t.Errorf("Authentication category: got %v", ch)
 	}
-	if items, ok := ch["security"]; !ok || len(items) != 1 || items[0] != "Fixed auth token validation" {
-		t.Errorf("security area: got %v", ch["security"])
-	}
-	// group_N keys should NOT be present after remapping
-	if _, ok := ch["group_1"]; ok {
-		t.Error("group_1 key should be remapped to core, not present in result")
-	}
-	if _, ok := ch["group_2"]; ok {
-		t.Error("group_2 key should be remapped to security, not present in result")
+	if items, ok := ch["API"]; !ok || len(items) != 1 {
+		t.Errorf("API category: got %v", ch)
 	}
 }
 
-func TestAdapter_GenerateChangelogByArea_EmptyNameMap_PreservesKeys(t *testing.T) {
-	// When nameMap is empty, group_N keys should be preserved as-is (fallback behavior)
+func TestAdapter_GenerateChangelogGrouped_FreeformMode_NoNameMap(t *testing.T) {
+	// In freeform mode with nil nameMap, LLM-invented keys are preserved as-is
 	expectedResult := domain.ChangelogByArea{
-		"group_1": []string{"Added feature"},
+		"Features": []string{"Added new capability"},
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1734,23 +1721,23 @@ func TestAdapter_GenerateChangelogByArea_EmptyNameMap_PreservesKeys(t *testing.T
 	defer server.Close()
 
 	adapter := newTestAdapter(server)
-	ch, err := adapter.GenerateChangelogByArea("group_1:\n- feat: add feature", nil, "")
+	ch, err := adapter.GenerateChangelogGrouped("general:\n- feat: add feature", nil, "", "freeform")
 	if err != nil {
-		t.Fatalf("GenerateChangelogByArea failed: %v", err)
+		t.Fatalf("GenerateChangelogGrouped failed: %v", err)
 	}
-	// With nil nameMap, group_1 should remain (no remapping)
+	// LLM-invented category should be preserved
 	if len(ch) != 1 {
-		t.Fatalf("expected 1 area, got %d", len(ch))
+		t.Fatalf("expected 1 category, got %d", len(ch))
 	}
-	if items, ok := ch["group_1"]; !ok || len(items) != 1 {
-		t.Errorf("group_1 should be preserved when no nameMap, got %v", ch)
+	if items, ok := ch["Features"]; !ok || len(items) != 1 {
+		t.Errorf("Features category should be preserved, got %v", ch)
 	}
 }
 
-func TestAdapter_GenerateChangelogByArea_PromptUsesGroupN(t *testing.T) {
-	// Verify that the prompt sent to LLM contains group_N keys, not area names
+func TestAdapter_GenerateChangelogGrouped_PromptUsesFreeformFormat(t *testing.T) {
+	// Verify that the prompt sent to LLM in freeform mode contains the commits
 	expectedResult := domain.ChangelogByArea{
-		"group_1": []string{"Added feature"},
+		"Features": []string{"Added feature"},
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1758,14 +1745,13 @@ func TestAdapter_GenerateChangelogByArea_PromptUsesGroupN(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		// The prompt should contain "group_1" and NOT contain "core" or real area names
+		// The prompt should contain the commit content
 		promptContent := req.Messages[len(req.Messages)-1].Content
-		if !strings.Contains(promptContent, "group_1") {
-			t.Error("prompt should contain group_1 key, not area names")
+		if !strings.Contains(promptContent, "general:") {
+			t.Error("prompt should contain 'general:' section for no-scope commits")
 		}
-		if strings.Contains(promptContent, "core") {
-			// "core" could appear in commit subjects, but the GROUP LABELS should be group_N
-			// This is a soft check since "core" might appear in commit text
+		if !strings.Contains(promptContent, "feat: add feature") {
+			t.Error("prompt should contain the commit message")
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -1774,14 +1760,13 @@ func TestAdapter_GenerateChangelogByArea_PromptUsesGroupN(t *testing.T) {
 	defer server.Close()
 
 	adapter := newTestAdapter(server)
-	nameMap := map[string]string{"group_1": "core"}
-	_, err := adapter.GenerateChangelogByArea("group_1:\n- feat: add feature\n", nameMap, "")
+	_, err := adapter.GenerateChangelogGrouped("general:\n- feat: add feature\n", nil, "", "freeform")
 	if err != nil {
-		t.Fatalf("GenerateChangelogByArea failed: %v", err)
+		t.Fatalf("GenerateChangelogGrouped failed: %v", err)
 	}
 }
 
-func TestAdapter_GenerateChangelogByArea_InvalidJSON(t *testing.T) {
+func TestAdapter_GenerateChangelogGrouped_InvalidJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(chatCompletionResponse("not valid json at all"))
@@ -1789,7 +1774,7 @@ func TestAdapter_GenerateChangelogByArea_InvalidJSON(t *testing.T) {
 	defer server.Close()
 
 	adapter := newTestAdapter(server)
-	_, err := adapter.GenerateChangelogByArea("group_1:\n- feat: add", nil, "")
+	_, err := adapter.GenerateChangelogGrouped("general:\n- feat: add", nil, "", "freeform")
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -9,9 +9,9 @@ import (
 
 // ProjectConfig holds per-project settings stored in .git-courer/config.json.
 // These values are committable and shared by the team.
+// Legacy configs may contain "areas" field — it is silently ignored on load and not written on save.
 type ProjectConfig struct {
 	Description string              `json:"description"`
-	Areas       map[string][]string `json:"areas"`
 	PathTypes   map[string][]string `json:"path_types,omitempty"`
 	TestCommand string              `json:"test_command"`
 	UserName    string              `json:"user_name,omitempty"`
@@ -35,11 +35,6 @@ func LoadProjectConfig(workDir string) (*ProjectConfig, error) {
 	cfg := &ProjectConfig{}
 	if err := json.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse project config: %w", err)
-	}
-
-	// Initialize empty map if Areas was nil (JSON missing the key)
-	if cfg.Areas == nil {
-		cfg.Areas = make(map[string][]string)
 	}
 
 	// Initialize empty slice if Excluded was nil (JSON missing the key)
@@ -74,7 +69,6 @@ func SaveProjectConfig(workDir string, cfg *ProjectConfig) error {
 
 	// Merge structured fields into raw map
 	raw["description"] = cfg.Description
-	raw["areas"] = cfg.Areas
 	if len(cfg.PathTypes) > 0 {
 		raw["path_types"] = cfg.PathTypes
 	} else {

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestProjectConfig_LoadExisting reads an existing config.json with description and areas,
+// TestProjectConfig_LoadExisting reads an existing config.json with description,
 // verifies test_command is empty string (default) if not present.
+// Legacy configs with "areas" field load without error.
 func TestProjectConfig_LoadExisting(t *testing.T) {
 	tmpDir := t.TempDir()
 	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
@@ -31,8 +32,7 @@ func TestProjectConfig_LoadExisting(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "test project", cfg.Description)
 	assert.Equal(t, "", cfg.TestCommand, "test_command should default to empty string when missing")
-	assert.Contains(t, cfg.Areas, "core")
-	assert.Equal(t, []string{"internal/"}, cfg.Areas["core"])
+	// Legacy "areas" field is ignored — not in struct
 }
 
 // TestProjectConfig_LoadWithTestCommand verifies loading config with test_command set.
@@ -43,7 +43,6 @@ func TestProjectConfig_LoadWithTestCommand(t *testing.T) {
 
 	existing := map[string]interface{}{
 		"description":  "test project",
-		"areas":        map[string]interface{}{},
 		"test_command": "make test-ci",
 	}
 	data, err := json.MarshalIndent(existing, "", "  ")
@@ -61,9 +60,6 @@ func TestProjectConfig_SaveNew(t *testing.T) {
 
 	cfg := &ProjectConfig{
 		Description: "test project",
-		Areas: map[string][]string{
-			"core": {"internal/"},
-		},
 		TestCommand: "make test",
 	}
 
@@ -74,11 +70,11 @@ func TestProjectConfig_SaveNew(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "test project", loaded.Description)
 	assert.Equal(t, "make test", loaded.TestCommand)
-	assert.Equal(t, []string{"internal/"}, loaded.Areas["core"])
 }
 
-// TestProjectConfig_SavePreservesExistingFields loads a config with description and areas,
+// TestProjectConfig_SavePreservesExistingFields loads a config with description,
 // adds test_command, saves, then reloads to verify all fields are preserved.
+// Legacy "areas" field in file is ignored on load and not written on save.
 func TestProjectConfig_SavePreservesExistingFields(t *testing.T) {
 	tmpDir := t.TempDir()
 	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
@@ -103,13 +99,12 @@ func TestProjectConfig_SavePreservesExistingFields(t *testing.T) {
 	// Save
 	require.NoError(t, SaveProjectConfig(tmpDir, cfg))
 
-	// Reload and verify all fields
+	// Reload and verify fields
 	loaded, err := LoadProjectConfig(tmpDir)
 	require.NoError(t, err)
 	assert.Equal(t, "existing project", loaded.Description)
 	assert.Equal(t, "go test ./...", loaded.TestCommand)
-	assert.Equal(t, []string{"internal/"}, loaded.Areas["core"])
-	assert.Equal(t, []string{"docs/"}, loaded.Areas["docs"])
+	// Legacy "areas" is not loaded into struct
 }
 
 // TestProjectConfig_LoadNonExistent returns an error when .git-courer/config.json doesn't exist.
@@ -121,15 +116,18 @@ func TestProjectConfig_LoadNonExistent(t *testing.T) {
 	assert.Contains(t, err.Error(), "no project config found")
 }
 
-// TestProjectConfig_LoadEmptyAreas handles areas as nil when JSON has no areas key.
-func TestProjectConfig_LoadEmptyAreas(t *testing.T) {
+// TestProjectConfig_LoadLegacyAreas verifies that legacy configs with "areas" field
+// load without error — the field is silently ignored.
+func TestProjectConfig_LoadLegacyAreas(t *testing.T) {
 	tmpDir := t.TempDir()
 	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
-		"description": "minimal project",
-		// No areas key
+		"description": "legacy config",
+		"areas": map[string]interface{}{
+			"core": []string{"internal/"},
+		},
 	}
 	data, err := json.MarshalIndent(existing, "", "  ")
 	require.NoError(t, err)
@@ -137,9 +135,8 @@ func TestProjectConfig_LoadEmptyAreas(t *testing.T) {
 
 	cfg, err := LoadProjectConfig(tmpDir)
 	require.NoError(t, err)
-	assert.Equal(t, "minimal project", cfg.Description)
-	assert.Empty(t, cfg.Areas)
-	assert.Equal(t, "", cfg.TestCommand)
+	assert.Equal(t, "legacy config", cfg.Description)
+	// areas field is ignored — no error, no data
 }
 
 // TestProjectConfig_SaveRoundTripUnknownFields verifies that unknown JSON fields
@@ -216,9 +213,6 @@ func TestProjectConfig_SaveExcluded(t *testing.T) {
 
 	cfg := &ProjectConfig{
 		Description: "test project",
-		Areas: map[string][]string{
-			"core": {"internal/"},
-		},
 		TestCommand: "go test ./...",
 		Excluded:    []string{"docs", "scripts", ".github"},
 	}

--- a/internal/core/domain/project_config.go
+++ b/internal/core/domain/project_config.go
@@ -30,6 +30,7 @@ var DefaultPathTypes = map[string][]string{
 type ProjectConfig struct {
 	Description string              `json:"description"`
 	PathTypes   map[string][]string `json:"path_types,omitempty"`
+	TestCommand string              `json:"test_command,omitempty"`
 	BaseBranch  string              `json:"base_branch,omitempty"`
 	Excluded    []string            `json:"excluded,omitempty"`
 }

--- a/internal/core/domain/project_config.go
+++ b/internal/core/domain/project_config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 )
 
@@ -25,13 +24,11 @@ var DefaultPathTypes = map[string][]string{
 
 // ProjectConfig persists repository metadata for the commit classification system.
 //
-// Trailing slash rule: all path prefixes in Areas, PathTypes, and Excluded MUST end
-// with "/" because matching uses strings.HasPrefix.  A prefix like "docs" would match
-// "docsify/foo.go", while "docs/" only matches paths under the docs directory.
+// Trailing slash rule: all path prefixes in PathTypes and Excluded MUST end
+// with "/" to avoid partial matches (e.g. "docs/" won't match "docsify/foo.go").
 // LoadProjectConfig normalises missing trailing slashes at load time.
 type ProjectConfig struct {
 	Description string              `json:"description"`
-	Areas       map[string][]string `json:"areas"`
 	PathTypes   map[string][]string `json:"path_types,omitempty"`
 	BaseBranch  string              `json:"base_branch,omitempty"`
 	Excluded    []string            `json:"excluded,omitempty"`
@@ -39,11 +36,12 @@ type ProjectConfig struct {
 
 // LoadProjectConfig reads the project configuration from disk.
 // If the config file does not exist, it returns an empty config.
+// Legacy configs with "areas" field load successfully — the field is ignored.
 func LoadProjectConfig(repoRoot string) (*ProjectConfig, error) {
 	path := filepath.Join(repoRoot, ".git-courer", "config.json")
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return &ProjectConfig{Areas: make(map[string][]string)}, nil
+		return &ProjectConfig{}, nil
 	}
 
 	data, err := os.ReadFile(path)
@@ -54,9 +52,6 @@ func LoadProjectConfig(repoRoot string) (*ProjectConfig, error) {
 	var cfg ProjectConfig
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
-	}
-	if cfg.Areas == nil {
-		cfg.Areas = make(map[string][]string)
 	}
 	if cfg.Excluded == nil {
 		cfg.Excluded = []string{}
@@ -91,7 +86,6 @@ func (c *ProjectConfig) Save(repoRoot string) error {
 // (e.g. "docs" matching "docsify/foo.go"). Directories without a trailing slash
 // are rare in config but would cause subtle bugs, so we fix them silently.
 func (c *ProjectConfig) normalise() {
-	c.Areas = normalisePrefixMap(c.Areas)
 	c.PathTypes = normalisePrefixMap(c.PathTypes)
 	c.Excluded = normalisePrefixSlice(c.Excluded)
 }
@@ -115,54 +109,7 @@ func normalisePrefixSlice(s []string) []string {
 	return s
 }
 
-// Rules:
-// 1. Cross chunk.Files paths with area paths.
-// 2. Multiple matches -> area with most files wins.
-// 3. Tie -> first area in config wins.
-// 4. No match -> empty string.
-func (c *ProjectConfig) ResolveScope(files []string) string {
-	if len(c.Areas) == 0 || len(files) == 0 {
-		return ""
-	}
 
-	type areaCount struct {
-		area  string
-		count int
-	}
-
-	counts := make([]areaCount, 0, len(c.Areas))
-
-	for area, prefixes := range c.Areas {
-		matched := 0
-		for _, file := range files {
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(file, prefix) {
-					matched++
-					break
-				}
-			}
-		}
-		if matched > 0 {
-			counts = append(counts, areaCount{area: area, count: matched})
-		}
-	}
-
-	if len(counts) == 0 {
-		return ""
-	}
-
-	winner := counts[0]
-	for _, ac := range counts[1:] {
-		if ac.count > winner.count {
-			winner = ac
-		} else if ac.count == winner.count && ac.area < winner.area {
-			// Deterministic tie-break: lexicographically smallest area name wins.
-			winner = ac
-		}
-	}
-
-	return winner.area
-}
 
 // ResolvePathType maps a set of changed files to a commit type based on path prefixes.
 // Returns the type only when ALL files match its prefixes (unanimity).
@@ -236,79 +183,9 @@ func (c *ProjectConfig) IsExcluded(path string) bool {
 	return false
 }
 
-// NewDirectories returns directory prefixes from files that have no area
-// mapping and are not excluded. Results are deduplicated and sorted.
-func (c *ProjectConfig) NewDirectories(files []string) []string {
-	seen := make(map[string]bool)
-	var dirs []string
-
-	for _, file := range files {
-		if c.IsExcluded(file) {
-			continue
-		}
-
-		// Find the longest-prefix area match
-		maxLen := 0
-		for _, prefixes := range c.Areas {
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(file, prefix) && len(prefix) > maxLen {
-					maxLen = len(prefix)
-				}
-			}
-		}
-
-		// If no area covers this file, extract the directory part
-		if maxLen == 0 {
-			dir := filepath.Dir(file)
-			if dir == "." {
-				dir = ""
-			}
-			if dir != "" && !seen[dir] {
-				seen[dir] = true
-				dirs = append(dirs, dir)
-			}
-		}
-	}
-
-	sort.Strings(dirs)
-	return dirs
-}
-
 // FormatScopeContext produces a human-readable scope string from the project config,
 // suitable for injecting into commit prompts via SetContext().
-// Format: "description\nareas: key=path1,path2\n..."
-// Returns empty string if config has neither description nor areas.
+// Returns only the description (no areas).
 func (c *ProjectConfig) FormatScopeContext() string {
-	if c.Description == "" && len(c.Areas) == 0 {
-		return ""
-	}
-
-	var parts []string
-
-	if c.Description != "" {
-		parts = append(parts, c.Description)
-	}
-
-	if len(c.Areas) > 0 {
-		areaLines := make([]string, 0, len(c.Areas))
-		// Sort area names for deterministic output (map iteration is random)
-		sortedAreas := sortedKeys(c.Areas)
-		for _, area := range sortedAreas {
-			paths := c.Areas[area]
-			areaLines = append(areaLines, fmt.Sprintf("%s=%s", area, strings.Join(paths, ",")))
-		}
-		parts = append(parts, "areas: "+strings.Join(areaLines, "; "))
-	}
-
-	return strings.Join(parts, "\n")
-}
-
-// sortedKeys returns map keys in sorted order for deterministic output.
-func sortedKeys(m map[string][]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
+	return c.Description
 }

--- a/internal/core/domain/project_config_test.go
+++ b/internal/core/domain/project_config_test.go
@@ -3,7 +3,6 @@ package domain
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -12,8 +11,8 @@ func TestProjectConfig_LoadSave(t *testing.T) {
 	tmpDir := t.TempDir()
 	config := &ProjectConfig{
 		Description: "A git commit helper",
-		Areas: map[string][]string{
-			"security": {"internal/auth", "internal/crypto"},
+		PathTypes: map[string][]string{
+			"test": {"test/"},
 		},
 	}
 
@@ -29,8 +28,8 @@ func TestProjectConfig_LoadSave(t *testing.T) {
 	if loaded.Description != config.Description {
 		t.Errorf("Description = %q, want %q", loaded.Description, config.Description)
 	}
-	if len(loaded.Areas["security"]) != 2 {
-		t.Errorf("Areas[security] len = %d, want 2", len(loaded.Areas["security"]))
+	if len(loaded.PathTypes["test"]) != 1 {
+		t.Errorf("PathTypes[test] len = %d, want 1", len(loaded.PathTypes["test"]))
 	}
 }
 
@@ -44,11 +43,8 @@ func TestProjectConfig_MissingConfig(t *testing.T) {
 	if loaded.Description != "" {
 		t.Errorf("Description = %q, want empty string", loaded.Description)
 	}
-	if loaded.Areas == nil {
-		t.Error("Areas should be empty map, not nil")
-	}
-	if len(loaded.Areas) != 0 {
-		t.Errorf("len(Areas) = %d, want 0", len(loaded.Areas))
+	if len(loaded.PathTypes) != 0 {
+		t.Errorf("len(PathTypes) = %d, want 0", len(loaded.PathTypes))
 	}
 }
 
@@ -69,104 +65,18 @@ func TestProjectConfig_MalformedJSON(t *testing.T) {
 	}
 }
 
-func TestProjectConfig_ResolveScope_SingleMatch(t *testing.T) {
-	t.Parallel()
-	config := &ProjectConfig{
-		Areas: map[string][]string{
-			"security": {"internal/auth", "internal/crypto"},
-		},
-	}
-	scope := config.ResolveScope([]string{"internal/auth/login.go", "internal/auth/tokens.go"})
-	if scope != "security" {
-		t.Errorf("ResolveScope = %q, want security", scope)
-	}
-}
-
-func TestProjectConfig_ResolveScope_MultipleAreasTie(t *testing.T) {
-	t.Parallel()
-	config := &ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-			"tui":  {"internal/ui"},
-		},
-	}
-	scope := config.ResolveScope([]string{"internal/core/domain.go", "internal/ui/screen.go"})
-	if scope != "core" {
-		t.Errorf("ResolveScope = %q, want core (first in config wins)", scope)
-	}
-}
-
-func TestProjectConfig_ResolveScope_NoMatch(t *testing.T) {
-	t.Parallel()
-	config := &ProjectConfig{
-		Areas: map[string][]string{
-			"security": {"internal/auth"},
-		},
-	}
-	scope := config.ResolveScope([]string{"pkg/utils/helpers.go"})
-	if scope != "" {
-		t.Errorf("ResolveScope = %q, want empty string", scope)
-	}
-}
-
-func TestProjectConfig_ResolveScope_NoAreasConfigured(t *testing.T) {
-	t.Parallel()
-	config := &ProjectConfig{}
-	scope := config.ResolveScope([]string{"internal/auth/login.go"})
-	if scope != "" {
-		t.Errorf("ResolveScope = %q, want empty string", scope)
-	}
-}
-
-func TestProjectConfig_ResolveScope_MostFilesWins(t *testing.T) {
-	t.Parallel()
-	config := &ProjectConfig{
-		Areas: map[string][]string{
-			"security": {"internal/auth"},
-			"core":     {"internal/core"},
-		},
-	}
-	scope := config.ResolveScope([]string{
-		"internal/core/domain.go",
-		"internal/core/ports.go",
-		"internal/auth/login.go",
-	})
-	if scope != "core" {
-		t.Errorf("ResolveScope = %q, want core (most files wins)", scope)
-	}
-}
-
 // --- FormatScopeContext tests ---
 
-func TestProjectConfig_FormatScopeContext_WithAreas(t *testing.T) {
+func TestProjectConfig_FormatScopeContext_DescriptionOnly(t *testing.T) {
 	t.Parallel()
 	config := &ProjectConfig{
-		Description: "A git helper",
-		Areas: map[string][]string{
-			"security": {"internal/auth/", "internal/crypto/"},
-			"core":     {"internal/core/domain/", "internal/core/ports/"},
-		},
+		Description: "My project",
 	}
 
 	result := config.FormatScopeContext()
 
-	if result == "" {
-		t.Fatal("FormatScopeContext() returned empty string, expected non-empty scope context")
-	}
-	// Must contain description
-	if !strings.Contains(result, "A git helper") {
-		t.Errorf("FormatScopeContext() missing description; got:\n%s", result)
-	}
-	// Must contain area names
-	if !strings.Contains(result, "security") {
-		t.Errorf("FormatScopeContext() missing area 'security'; got:\n%s", result)
-	}
-	if !strings.Contains(result, "core") {
-		t.Errorf("FormatScopeContext() missing area 'core'; got:\n%s", result)
-	}
-	// Must contain path mappings
-	if !strings.Contains(result, "internal/auth/") {
-		t.Errorf("FormatScopeContext() missing path 'internal/auth/'; got:\n%s", result)
+	if result != "My project" {
+		t.Errorf("FormatScopeContext() = %q, want %q", result, "My project")
 	}
 }
 
@@ -181,24 +91,25 @@ func TestProjectConfig_FormatScopeContext_Empty(t *testing.T) {
 	}
 }
 
-func TestProjectConfig_FormatScopeContext_DescriptionOnly(t *testing.T) {
+// Test to verify ProjectConfig without Areas field compiles and loads correctly
+func TestProjectConfig_NoAreasField(t *testing.T) {
 	t.Parallel()
+	tmpDir := t.TempDir()
 	config := &ProjectConfig{
-		Description: "My project",
+		Description: "No areas project",
 	}
 
-	result := config.FormatScopeContext()
+	if err := config.Save(tmpDir); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
 
-	if !strings.Contains(result, "My project") {
-		t.Errorf("FormatScopeContext() missing description; got:\n%s", result)
+	loaded, err := LoadProjectConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig() error = %v", err)
 	}
-	// Should still have the description even without areas
-	if result == "" {
-		t.Error("FormatScopeContext() returned empty string for description-only config")
-	}
-	// Should NOT contain "areas:" if there are no areas
-	if strings.Contains(result, "areas:") {
-		t.Errorf("FormatScopeContext() should not contain 'areas:' with no areas; got:\n%s", result)
+
+	if loaded.Description != "No areas project" {
+		t.Errorf("Description = %q, want %q", loaded.Description, "No areas project")
 	}
 }
 
@@ -267,91 +178,7 @@ func TestProjectConfig_IsExcluded_PrefixMatching(t *testing.T) {
 	}
 }
 
-// --- NewDirectories tests ---
 
-func TestProjectConfig_NewDirectories_SomeDirsHaveNoArea(t *testing.T) {
-	t.Parallel()
-	cfg := &ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-	}
-	files := []string{
-		"internal/core/domain.go",
-		"internal/infra/cfg/db.go",
-	}
-	got := cfg.NewDirectories(files)
-	want := []string{"internal/infra/cfg"}
-	if len(got) != len(want) {
-		t.Fatalf("NewDirectories = %v, want %v", got, want)
-	}
-	for i, d := range got {
-		if d != want[i] {
-			t.Errorf("NewDirectories[%d] = %q, want %q", i, d, want[i])
-		}
-	}
-}
-
-func TestProjectConfig_NewDirectories_AllDirsMapped(t *testing.T) {
-	t.Parallel()
-	cfg := &ProjectConfig{
-		Areas: map[string][]string{
-			"security": {"internal/auth"},
-		},
-	}
-	files := []string{"internal/auth/login.go"}
-	got := cfg.NewDirectories(files)
-	if len(got) != 0 {
-		t.Errorf("NewDirectories = %v, want empty (all mapped)", got)
-	}
-}
-
-func TestProjectConfig_NewDirectories_ExcludedDirFilteredOut(t *testing.T) {
-	t.Parallel()
-	cfg := &ProjectConfig{}
-	// DefaultExcluded includes "docs"
-	files := []string{"docs/api.md", "internal/core/domain.go"}
-	got := cfg.NewDirectories(files)
-	for _, d := range got {
-		if d == "docs" || strings.HasPrefix(d, "docs/") {
-			t.Errorf("NewDirectories should not include excluded dir %q", d)
-		}
-	}
-}
-
-func TestProjectConfig_NewDirectories_NoAreasConfigured(t *testing.T) {
-	t.Parallel()
-	cfg := &ProjectConfig{}
-	// No areas, no excluded — everything is new
-	files := []string{"internal/core/domain.go"}
-	got := cfg.NewDirectories(files)
-	if len(got) != 1 || got[0] != "internal/core" {
-		t.Errorf("NewDirectories = %v, want [internal/core]", got)
-	}
-}
-
-func TestProjectConfig_NewDirectories_DeduplicatedAndSorted(t *testing.T) {
-	t.Parallel()
-	cfg := &ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-	}
-	// Two files in same directory should produce one entry
-	files := []string{
-		"internal/core/domain.go",
-		"internal/core/ports.go",
-		"internal/infra/cfg/a.go",
-		"internal/infra/cfg/b.go",
-	}
-	got := cfg.NewDirectories(files)
-	if len(got) != 1 {
-		t.Errorf("NewDirectories = %v, want 1 unique directory, got %d", got, len(got))
-	}
-	if len(got) > 0 && got[0] != "internal/infra/cfg" {
-		t.Errorf("NewDirectories[0] = %q, want %q", got[0], "internal/infra/cfg")
-	}
-}
 
 // --- ResolvePathType tests ---
 
@@ -429,10 +256,7 @@ func TestProjectConfig_BaseBranch_RoundTrip(t *testing.T) {
 	tmpDir := t.TempDir()
 	config := &ProjectConfig{
 		Description: "test project",
-		Areas: map[string][]string{
-			"core": {"internal/core/"},
-		},
-		BaseBranch: "main",
+		BaseBranch:  "main",
 	}
 
 	if err := config.Save(tmpDir); err != nil {
@@ -457,7 +281,7 @@ func TestProjectConfig_BaseBranch_DefaultEmpty(t *testing.T) {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
 	// Config with no base_branch key
-	configJSON := `{"description":"test","areas":{"core":["internal/core/"]}}`
+	configJSON := `{"description":"test"}`
 	if err := os.WriteFile(filepath.Join(repoDir, "config.json"), []byte(configJSON), 0644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}

--- a/internal/delivery/mcp/core/commit_handler.go
+++ b/internal/delivery/mcp/core/commit_handler.go
@@ -90,7 +90,7 @@ func (h *Handler) loadProjectConfig() *domain.ProjectConfig {
 	}
 	cfg, err := domain.LoadProjectConfig(h.workDir)
 	if err != nil {
-		return &domain.ProjectConfig{Areas: make(map[string][]string)}
+		return &domain.ProjectConfig{}
 	}
 	return cfg
 }

--- a/internal/delivery/mcp/core/handler_test.go
+++ b/internal/delivery/mcp/core/handler_test.go
@@ -1925,7 +1925,7 @@ func TestHandlePreview_BaseBranchConfigured_UsesMergeBase(t *testing.T) {
 	h := NewHandler(mGit, commitSvc, rev, mLLM, "", nil, nil)
 	// Override configProvider to return a config with BaseBranch = "develop"
 	h.configProvider = func() *domain.ProjectConfig {
-		return &domain.ProjectConfig{BaseBranch: "develop", Areas: map[string][]string{}}
+		return &domain.ProjectConfig{BaseBranch: "develop"}
 	}
 
 	args := map[string]any{"command": "PREVIEW", "why": "test"}
@@ -1982,7 +1982,7 @@ func TestHandlePreview_BaseBranchIsCurrentBranch_SkipsReconciliation(t *testing.
 	h := NewHandler(mGit, commitSvc, rev, mLLM, "", nil, nil)
 	// Override configProvider to return BaseBranch = "main" (same as current branch)
 	h.configProvider = func() *domain.ProjectConfig {
-		return &domain.ProjectConfig{BaseBranch: "main", Areas: map[string][]string{}}
+		return &domain.ProjectConfig{BaseBranch: "main"}
 	}
 
 	args := map[string]any{"command": "PREVIEW", "why": "test"}
@@ -2040,7 +2040,7 @@ func TestHandlePreview_BaseBranchEmpty_FallsBackToHardcodedList(t *testing.T) {
 	h := NewHandler(mGit, commitSvc, rev, mLLM, "", nil, nil)
 	// Override configProvider to return an empty BaseBranch
 	h.configProvider = func() *domain.ProjectConfig {
-		return &domain.ProjectConfig{Areas: map[string][]string{}}
+		return &domain.ProjectConfig{}
 	}
 
 	args := map[string]any{"command": "PREVIEW", "why": "test"}
@@ -2091,7 +2091,7 @@ func TestHandlePreview_BaseBranchConfigured_MergeBaseError_ReturnsError(t *testi
 
 	h := NewHandler(mGit, commitSvc, rev, mLLM, "", nil, nil)
 	h.configProvider = func() *domain.ProjectConfig {
-		return &domain.ProjectConfig{BaseBranch: "develop", Areas: map[string][]string{}}
+		return &domain.ProjectConfig{BaseBranch: "develop"}
 	}
 
 	args := map[string]any{"command": "PREVIEW", "why": "test"}
@@ -2200,7 +2200,7 @@ func TestHandlePreview_StackMetadataInjected_WithBaseBranch(t *testing.T) {
 
 	h := NewHandler(mGit, commitSvc, rev, mLLM, "", nil, nil)
 	h.configProvider = func() *domain.ProjectConfig {
-		return &domain.ProjectConfig{BaseBranch: "develop", Areas: map[string][]string{}}
+		return &domain.ProjectConfig{BaseBranch: "develop"}
 	}
 
 	args := map[string]any{"command": "PREVIEW", "why": "test"}
@@ -2341,7 +2341,7 @@ func TestHandlePreview_StackMetadataEmpty_WhenBaseBranchEmpty(t *testing.T) {
 	h := NewHandler(mGit, commitSvc, rev, mLLM, "", nil, nil)
 	// Empty BaseBranch — no stack metadata should be injected
 	h.configProvider = func() *domain.ProjectConfig {
-		return &domain.ProjectConfig{Areas: map[string][]string{}}
+		return &domain.ProjectConfig{}
 	}
 
 	args := map[string]any{"command": "PREVIEW", "why": "test"}

--- a/internal/delivery/mcp/prreview/handler_test.go
+++ b/internal/delivery/mcp/prreview/handler_test.go
@@ -206,7 +206,6 @@ func TestPRReview_TestCommandFromProjectConfig(t *testing.T) {
 	// Create .git-courer/config.json with test_command
 	cfg := &config.ProjectConfig{
 		Description: "test project",
-		Areas:       map[string][]string{},
 		TestCommand: "go test ./...",
 	}
 	require.NoError(t, config.SaveProjectConfig(tmpDir, cfg))

--- a/internal/delivery/mcp/prreview/handler_test.go
+++ b/internal/delivery/mcp/prreview/handler_test.go
@@ -203,7 +203,6 @@ func TestPRReview_TestCommandFromProjectConfig(t *testing.T) {
 	git.On("DiffRange", "abc123", "feat/branch", "..").Return("", nil)
 
 	tmpDir := t.TempDir()
-	// Create .git-courer/config.json with test_command
 	cfg := &config.ProjectConfig{
 		Description: "test project",
 		TestCommand: "go test ./...",
@@ -249,7 +248,6 @@ func TestPRReview_TestFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := &config.ProjectConfig{
 		Description: "test project",
-		Areas:       map[string][]string{},
 		TestCommand: "go test ./...",
 	}
 	require.NoError(t, config.SaveProjectConfig(tmpDir, cfg))
@@ -303,7 +301,6 @@ func TestPRReview_Conflict(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := &config.ProjectConfig{
 		Description: "test project",
-		Areas:       map[string][]string{},
 		TestCommand: "go test ./...",
 	}
 	require.NoError(t, config.SaveProjectConfig(tmpDir, cfg))
@@ -403,7 +400,6 @@ func TestPRReview_DiffStats(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := &config.ProjectConfig{
 		Description: "test project",
-		Areas:       map[string][]string{},
 		TestCommand: "go test ./...",
 	}
 	require.NoError(t, config.SaveProjectConfig(tmpDir, cfg))

--- a/internal/delivery/mcp/utility/handler_test.go
+++ b/internal/delivery/mcp/utility/handler_test.go
@@ -281,19 +281,14 @@ func TestHandler_HandleConfig_SetTestCommand_WritesToProjectConfig(t *testing.T)
 	loaded, err := config.LoadProjectConfig(tmpDir)
 	require.NoError(t, err)
 	assert.Equal(t, "make test-ci", loaded.TestCommand)
-	assert.NotNil(t, loaded.Areas)
 }
 
 func TestHandler_HandleConfig_SetTestCommand_PreservesExistingFields(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Pre-create .git-courer/config.json with description and areas
+	// Pre-create .git-courer/config.json with description
 	existing := &config.ProjectConfig{
 		Description: "existing project",
-		Areas: map[string][]string{
-			"core": {"internal/"},
-			"docs": {"docs/"},
-		},
 		TestCommand: "",
 	}
 	require.NoError(t, config.SaveProjectConfig(tmpDir, existing))
@@ -319,8 +314,6 @@ func TestHandler_HandleConfig_SetTestCommand_PreservesExistingFields(t *testing.
 	require.NoError(t, err)
 	assert.Equal(t, "existing project", loaded.Description)
 	assert.Equal(t, "pytest", loaded.TestCommand)
-	assert.Equal(t, []string{"internal/"}, loaded.Areas["core"])
-	assert.Equal(t, []string{"docs/"}, loaded.Areas["docs"])
 }
 
 func TestHandler_HandleConfig_SetTestCommand_EmptyString(t *testing.T) {
@@ -329,7 +322,6 @@ func TestHandler_HandleConfig_SetTestCommand_EmptyString(t *testing.T) {
 	// Pre-create config with existing test_command
 	existing := &config.ProjectConfig{
 		Description: "test project",
-		Areas:       map[string][]string{},
 		TestCommand: "old-command",
 	}
 	require.NoError(t, config.SaveProjectConfig(tmpDir, existing))
@@ -733,7 +725,6 @@ func TestHandler_HandleConfig_GET_ReturnsProject(t *testing.T) {
 	// Pre-create a project config
 	existing := &config.ProjectConfig{
 		Description: "test project",
-		Areas:       map[string][]string{"core": {"internal/"}},
 		TestCommand: "make test",
 		UserName:    "Ada Lovelace",
 		UserEmail:   "ada@example.com",
@@ -943,7 +934,6 @@ func TestHandler_HandleConfig_SetSigningKey_PreservesExistingFields(t *testing.T
 	tmpDir := t.TempDir()
 	existing := &config.ProjectConfig{
 		Description: "my project",
-		Areas:       map[string][]string{"core": {"internal/"}},
 		TestCommand: "make test",
 		UserName:    "Ada",
 	}

--- a/internal/delivery/mcp/utility/handlers.go
+++ b/internal/delivery/mcp/utility/handlers.go
@@ -150,7 +150,6 @@ func (h *Handler) writeProjectTestCommand(testCmd string) error {
 		// If no project config exists, create a new one
 		cfg = &config.ProjectConfig{
 			Description: "",
-			Areas:       make(map[string][]string),
 		}
 	}
 	cfg.TestCommand = testCmd
@@ -161,9 +160,7 @@ func (h *Handler) writeProjectTestCommand(testCmd string) error {
 func (h *Handler) writeProjectConfigField(field, value string) error {
 	cfg, err := config.LoadProjectConfig(h.workDir)
 	if err != nil {
-		cfg = &config.ProjectConfig{
-			Areas: make(map[string][]string),
-		}
+		cfg = &config.ProjectConfig{}
 	}
 	switch field {
 	case "user_name":

--- a/internal/shared/prompts/md/changelog.md
+++ b/internal/shared/prompts/md/changelog.md
@@ -11,13 +11,14 @@ This instruction OVERRIDES every example and style guide below — those show FO
 {{if .Context}}## Project Context
 {{.Context}}
 {{end}}
-## Commits by area
+## Commits
+
 {{.Groups}}
 
 {{if .CustomMessage}}## Author Notes
 {{.CustomMessage}}
 
-The author decides what matters most. Generate changelog for ALL commits below, but highlight what the author says is important and place items in the area/section the author requests.
+The author decides what matters most. Generate changelog for ALL commits below, but highlight what the author says is important.
 {{end}}
 ## Task
 You are a world-class product writer (like the ones at Stripe, Linear, or Vercel).
@@ -40,28 +41,28 @@ Your ONLY job is to communicate WHY each change exists — the problem, the moti
 
 5. **Skip Merge and Internal Noise**: No branch merges, CI/CD, test-only changes.
 
-6. **Use ONLY the input keys**: Output must use the exact keys from input. Never invent keys.
+6. **Invent Your Own Categories**: Look at ALL the commits below. Invent meaningful category names that group related changes together. Use real descriptive names like "Authentication", "API Improvements", "Developer Experience" — NOT generic labels like "group_1" or "Category A".
 
 ## Tone
 Professional, clear, friendly, concise. Active verbs. Write like a human explaining to another human why a problem got solved.
 
 ## Output Format
-Return a **flat** JSON object. Each key from input maps to an **array of strings**, NOT to another object.
+Return a **flat** JSON object. Each key is a category name YOU invent, mapping to an **array of strings** (bullet points).
 
 ✅ CORRECT:
 ```json
-{"group_1": ["Metadata could be lost during squash operations — now the system auto-stages .git-courer files so commit history is never lost", "Developers couldn't inspect specific log periods — now you can query by date range"]}
+{"Authentication": ["Added login flow with JWT tokens so users can securely access their accounts", "Implemented token refresh to prevent unexpected logouts"], "API": ["Exposed webhook endpoints for third-party integrations"]}
 ```
 
 ❌ WRONG (nested objects):
 ```json
-{"group_4": {"core": ["Esto es lo que se hizo"]}}
+{"Authentication": {"items": ["Added login"]}}
 ```
 
-❌ WRONG (invented keys):
+❌ WRONG (obfuscated keys):
 ```json
-{"group_4": ["item"], "group_4_extra": ["item"]}
+{"group_1": ["Added login"], "group_2": ["Added webhooks"]}
 ```
 
-Use ONLY the input keys you receive. Never rename, nest, or extend them.
+Use meaningful category names that reflect the actual content. Never use generic placeholders like "group_N", "Category A", or "Section 1".
 {{if .CustomMessage}}CRITICAL: every string in the output MUST be in the same language as the Author Notes above.{{end}}

--- a/internal/shared/prompts/prompts.go
+++ b/internal/shared/prompts/prompts.go
@@ -93,9 +93,17 @@ func GetClassifyBinary() string {
 	return tmpl
 }
 
+// GetChangelog returns the changelog template (freeform mode)
+func GetChangelog() string {
+	tmpl, _ := Get("changelog")
+	return tmpl
+}
+
 // GetChangelogAreas returns the changelog_areas template
+// Deprecated: Use GetChangelog() for freeform mode
 func GetChangelogAreas() string {
-	tmpl, _ := Get("changelog_areas")
+	// Fallback to changelog template since changelog_areas.md was removed
+	tmpl, _ := Get("changelog")
 	return tmpl
 }
 

--- a/internal/shared/prompts/prompts_test.go
+++ b/internal/shared/prompts/prompts_test.go
@@ -170,15 +170,20 @@ func TestRender_CommitMessage_WhyOmitted_WhenEmpty(t *testing.T) {
 	}
 }
 
-func TestGetChangelogAreas(t *testing.T) {
-	tmpl := GetChangelogAreas()
+func TestGetChangelog(t *testing.T) {
+	tmpl := GetChangelog()
 	if tmpl == "" {
-		t.Error("GetChangelogAreas() returned empty string")
+		t.Error("GetChangelog() returned empty string")
 	}
-	if !strings.Contains(tmpl, "group_1") {
-		t.Error("changelog_areas.md should contain 'group_1' in output schema")
+	// Freeform changelog should instruct LLM to invent its own categories
+	if !strings.Contains(tmpl, "Invent Your Own Categories") {
+		t.Error("changelog.md should instruct LLM to invent its own categories")
 	}
+	if !strings.Contains(tmpl, "JSON only") {
+		t.Error("changelog.md should specify JSON-only output")
+	}
+	// Should NOT contain old area-based concepts
 	if strings.Contains(tmpl, "area_name") {
-		t.Error("changelog_areas.md should NOT contain area names like 'area_name'")
+		t.Error("changelog.md should NOT contain area names like 'area_name'")
 	}
 }

--- a/internal/workflow/commit.go
+++ b/internal/workflow/commit.go
@@ -269,7 +269,6 @@ func (s *CommitService) prepareStages(instruction string) (*preparedState, error
 	}
 
 	s.classifyChunks(chunks)
-	s.resolveChunkScopes(chunks)
 
 	// Clean up internal fields after classification.
 	// AST source data was used by the classifier — no longer needed by the LLM.
@@ -289,16 +288,6 @@ func (s *CommitService) prepareStages(instruction string) (*preparedState, error
 	decision := domain.CommitIntent{IncludeUntracked: false, Filter: stagedFiles}
 
 	return &preparedState{chunks: chunks, deleted: deleted, decision: decision}, nil
-}
-
-// resolveChunkScopes assigns the functional area scope to each chunk using the project config.
-func (s *CommitService) resolveChunkScopes(chunks []domain.DiffChunk) {
-	if s.projectCfg == nil || len(s.projectCfg.Areas) == 0 {
-		return
-	}
-	for i := range chunks {
-		chunks[i].Scope = s.projectCfg.ResolveScope(chunks[i].Files)
-	}
 }
 
 // classifyChunks runs the message classifier on each annotated chunk. Results
@@ -418,9 +407,8 @@ func (s *CommitService) prepareChunksAndMessages(instruction, feedback string) (
 		// Happy path: combine all chunks into a single DiffChunk
 		combinedChunk := s.combineChunks(state.chunks)
 
-		// Run classification and scope resolution on the combined chunk
+		// Run classification on the combined chunk
 		s.classifyChunks([]domain.DiffChunk{combinedChunk})
-		s.resolveChunkScopes([]domain.DiffChunk{combinedChunk})
 
 		// Generate the commit message
 		var msg string
@@ -497,7 +485,6 @@ func (s *CommitService) prepareChunksAndMessages(instruction, feedback string) (
 				log.Printf("[WARN] Failed to annotate chunks for %s: %v", fPath, err)
 			}
 			s.classifyChunks(fChunks)
-			s.resolveChunkScopes(fChunks)
 
 			// 4. Generate messages for the file chunks
 			var fMsg string
@@ -556,7 +543,6 @@ func (s *CommitService) prepareChunksAndMessages(instruction, feedback string) (
 		// but the LLM call can handle it or gracefully fallback.
 		combinedChunk := s.combineChunks(state.chunks)
 		s.classifyChunks([]domain.DiffChunk{combinedChunk})
-		s.resolveChunkScopes([]domain.DiffChunk{combinedChunk})
 
 		var msg string
 		if s.llm != nil {

--- a/internal/workflow/context_test.go
+++ b/internal/workflow/context_test.go
@@ -91,9 +91,7 @@ func TestNewCommitService_ProjectConfigScopeInjection(t *testing.T) {
 	if !strings.Contains(llm.contextSet, "Test project for scope injection") {
 		t.Errorf("contextSet = %q, want to contain project description", llm.contextSet)
 	}
-	if !strings.Contains(llm.contextSet, "core") {
-		t.Errorf("contextSet = %q, want to contain area 'core'", llm.contextSet)
-	}
+	// Areas system removed in Phase 2 — context should contain project description only, not area names
 }
 
 func TestNewCommitService_ContextConfigTakesPrecedence(t *testing.T) {

--- a/internal/workflow/context_test.go
+++ b/internal/workflow/context_test.go
@@ -63,9 +63,6 @@ func TestNewCommitService_ProjectConfigScopeInjection(t *testing.T) {
 	tmpDir := t.TempDir()
 	config := &domain.ProjectConfig{
 		Description: "Test project for scope injection",
-		Areas: map[string][]string{
-			"core": {"internal/core/"},
-		},
 	}
 	if err := config.Save(tmpDir); err != nil {
 		t.Fatalf("Save() error: %v", err)
@@ -103,7 +100,6 @@ func TestNewCommitService_ContextConfigTakesPrecedence(t *testing.T) {
 	tmpDir := t.TempDir()
 	config := &domain.ProjectConfig{
 		Description: "Project config description",
-		Areas:       map[string][]string{"auth": {"internal/auth/"}},
 	}
 	if err := config.Save(tmpDir); err != nil {
 		t.Fatalf("Save() error: %v", err)
@@ -264,9 +260,7 @@ func TestReleaseService_Generate_CallsSetContext(t *testing.T) {
 
 	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
 	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
+		Description: "Test project",
 	}
 	svc.SetContext(cfg.Context)
 

--- a/internal/workflow/release.go
+++ b/internal/workflow/release.go
@@ -116,6 +116,7 @@ func NewReleaseService(git ports.Git, llm ports.LLM, logChunker LogChunker, cfg 
 	} else {
 		if loaded, err := domain.LoadProjectConfig("."); err == nil && loaded != nil {
 			projectCfg = loaded
+			// FormatScopeContext now returns only description (no areas)
 			if scopeCtx := loaded.FormatScopeContext(); scopeCtx != "" {
 				if setter, ok := llm.(interface{ SetContext(string) }); ok {
 					setter.SetContext(scopeCtx)

--- a/internal/workflow/release_generate.go
+++ b/internal/workflow/release_generate.go
@@ -10,7 +10,7 @@ import (
 
 // Generate filters commits, groups them, and translates to user-facing markdown.
 // When BaseBranch is configured (non-empty), uses stack-based grouping.
-// When areas are configured (and BaseBranch is empty), uses area-based grouping.
+// Otherwise, uses freeform LLM-based categorization.
 // Always returns isBackground=false; the bool is kept for interface compatibility.
 // If a custom message was set via SetCustomMessage, it is injected into the LLM prompt.
 func (s *ReleaseService) Generate(commits string) (string, []string, bool, error) {
@@ -19,25 +19,17 @@ func (s *ReleaseService) Generate(commits string) (string, []string, bool, error
 		return s.generateWithStacks(commits)
 	}
 
-	// Area-based path (original): requires areas to be configured
-	if s.projectCfg == nil || len(s.projectCfg.Areas) == 0 {
-		return "", nil, false, fmt.Errorf("changelog generation requires project areas to be configured — run git-courer init")
-	}
-	return s.generateWithAreas(commits)
+	// Freeform path: LLM invents its own categories
+	return s.generateFreeform(commits)
 }
 
-// generateWithAreas produces an area-based changelog when areas are configured.
-// Filters by IsExcluded, groups by area with group_N obfuscation, calls LLM,
-// then remaps group_N keys back to area names.
-// If the formatted groups exceed the token threshold, splits into per-area calls.
-func (s *ReleaseService) generateWithAreas(commits string) (string, []string, bool, error) {
+// generateFreeform produces a freeform LLM-categorized changelog.
+// Filters commits, groups by scope, and lets the LLM invent category names.
+// No predefined keys, no area concepts, no obfuscation.
+// If the formatted groups exceed the token threshold, splits into per-group calls.
+func (s *ReleaseService) generateFreeform(commits string) (string, []string, bool, error) {
 	filtered := filterForChangelog(commits, s.projectCfg)
 	if len(filtered) == 0 {
-		return "", nil, false, nil
-	}
-
-	areaGroups, nameMap := groupByArea(filtered, s.projectCfg)
-	if len(areaGroups) == 0 {
 		return "", nil, false, nil
 	}
 
@@ -49,32 +41,29 @@ func (s *ReleaseService) generateWithAreas(commits string) (string, []string, bo
 	var changelog domain.ChangelogByArea
 	var err error
 
-	if shouldChunkChangelog(areaGroups, threshold) {
-		changelog, err = s.generateChangelogByAreaChunked(areaGroups, nameMap)
+	if shouldChunkChangelog(filtered, threshold) {
+		changelog, err = s.generateChangelogFreeformChunked(filtered)
 	} else {
-		formatted := FormatGroupedCommits(areaGroups)
-		changelog, err = s.llm.GenerateChangelogGrouped(formatted, nameMap, s.customMessage, "area")
+		formatted := FormatGroupedCommits(filtered)
+		changelog, err = s.llm.GenerateChangelogGrouped(formatted, nil, s.customMessage, "freeform")
 	}
 	if err != nil {
 		return "", []string{err.Error()}, false, err
 	}
 
-	// Remap group_N keys back to area names (already done in adapter with nameMap,
-	// but also safe to do here for chunked partial results)
-	remapped := remapGroupKeys(changelog, nameMap)
-	md := formatChangelogByAreaMarkdown(remapped)
+	md := formatChangelogByAreaMarkdown(changelog)
 	return md, nil, false, nil
 }
 
-// generateChangelogByAreaChunked calls LLM once per area group when the total
+// generateChangelogFreeformChunked calls LLM once per scope group when the total
 // context exceeds the threshold, then merges results.
 // It also splits large commit lists within a single group into smaller chunks
 // of 25 commits to prevent LLM attention overload and hallucination loops.
-func (s *ReleaseService) generateChangelogByAreaChunked(areaGroups map[string][]string, nameMap map[string]string) (domain.ChangelogByArea, error) {
+func (s *ReleaseService) generateChangelogFreeformChunked(groups map[string][]string) (domain.ChangelogByArea, error) {
 	result := make(domain.ChangelogByArea)
 	const chunkSize = 25
 
-	for groupKey, commits := range areaGroups {
+	for groupKey, commits := range groups {
 		if len(commits) == 0 {
 			continue
 		}
@@ -89,7 +78,7 @@ func (s *ReleaseService) generateChangelogByAreaChunked(areaGroups map[string][]
 			singleGroup := map[string][]string{groupKey: chunkCommits}
 			formatted := FormatGroupedCommits(singleGroup)
 
-			partial, err := s.llm.GenerateChangelogGrouped(formatted, nameMap, s.customMessage, "area")
+			partial, err := s.llm.GenerateChangelogGrouped(formatted, nil, s.customMessage, "freeform")
 			if err != nil {
 				allBullets = append(allBullets, fmt.Sprintf("(could not generate for commits %d-%d: %v)", i+1, end, err))
 				continue
@@ -146,61 +135,6 @@ func titleCase(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 
-// groupByArea maps scope-grouped commits to group_N keys for LLM obfuscation.
-// Areas are sorted alphabetically → group_1, group_2, etc.
-// Only scopes that match configured area names are included in area groups.
-// Returns the grouped map (keyed by group_N) and nameMap (group_N → area name).
-func groupByArea(groups map[string][]string, cfg *domain.ProjectConfig) (map[string][]string, map[string]string) {
-	if cfg == nil || len(cfg.Areas) == 0 {
-		return nil, nil
-	}
-
-	// Sort area names for deterministic group assignment
-	sortedAreas := make([]string, 0, len(cfg.Areas))
-	for area := range cfg.Areas {
-		sortedAreas = append(sortedAreas, area)
-	}
-	sort.Strings(sortedAreas)
-
-	// Build name map: area → group_N
-	areaToGroup := make(map[string]string)
-	nameMap := make(map[string]string)
-	for i, area := range sortedAreas {
-		groupKey := fmt.Sprintf("group_%d", i+1)
-		areaToGroup[area] = groupKey
-		nameMap[groupKey] = area
-	}
-
-	// Map commits from scope to group_N
-	result := make(map[string][]string)
-	for area, groupKey := range areaToGroup {
-		if commits, ok := groups[area]; ok {
-			result[groupKey] = commits
-		}
-	}
-	// Any scopeless commits go to a "general" group if present
-	if commits, ok := groups[""]; ok {
-		result["group_general"] = commits
-		nameMap["group_general"] = "general"
-	}
-
-	return result, nameMap
-}
-
-// remapGroupKeys replaces group_N keys in ChangelogByArea with the actual area names
-// using the nameMap obtained from groupByArea.
-func remapGroupKeys(ch domain.ChangelogByArea, nameMap map[string]string) domain.ChangelogByArea {
-	result := make(domain.ChangelogByArea)
-	for groupKey, items := range ch {
-		areaName, ok := nameMap[groupKey]
-		if !ok {
-			areaName = groupKey // fallback: keep group_N key
-		}
-		result[areaName] = items
-	}
-	return result
-}
-
 // estimateTokens provides a rough token estimate for a text string.
 // Uses ~4 chars per token as a conservative estimate.
 func estimateTokens(text string) int {
@@ -232,16 +166,13 @@ func (s *ReleaseService) generateWithStacks(commits string) (string, []string, b
 		filteredEntries = filterEntriesForChangelog(s.pendingEntries, s.projectCfg)
 	}
 
-	// If no stack entries (e.g., on trunk with no entries), fall back to area-based
+	// If no stack entries (e.g., on trunk with no entries), fall back to freeform
 	if len(filteredEntries) == 0 {
 		if len(commits) == 0 {
 			return "", nil, false, nil
 		}
-		// No stack data available — fall back to area-based if possible
-		if s.projectCfg != nil && len(s.projectCfg.Areas) > 0 {
-			return s.generateWithAreas(commits)
-		}
-		return "", nil, false, nil
+		// No stack data available — fall back to freeform
+		return s.generateFreeform(commits)
 	}
 
 	groups := domain.GroupByStackID(filteredEntries)
@@ -320,4 +251,18 @@ func (s *ReleaseService) generateWithStacks(commits string) (string, []string, b
 
 	md := formatChangelogByAreaMarkdown(remapped)
 	return md, nil, false, nil
+}
+
+// remapGroupKeys replaces group_N keys in ChangelogByArea with the actual display labels
+// using the nameMap obtained from stack grouping.
+func remapGroupKeys(ch domain.ChangelogByArea, nameMap map[string]string) domain.ChangelogByArea {
+	result := make(domain.ChangelogByArea)
+	for groupKey, items := range ch {
+		areaName, ok := nameMap[groupKey]
+		if !ok {
+			areaName = groupKey // fallback: keep group_N key
+		}
+		result[areaName] = items
+	}
+	return result
 }

--- a/internal/workflow/release_generate_test.go
+++ b/internal/workflow/release_generate_test.go
@@ -62,13 +62,13 @@ func TestFilterAndGroupCommits_FiltersInternalTypes(t *testing.T) {
 		"def5678 chore: update go.mod",
 		"ghi9012 ci: fix pipeline",
 		"jkl3456 build: update docker image",
-		"mno7890 feat(core): add semantic annotator",
+		"mno7890 feat: add semantic annotator",
 	}, "\n")
 
 	groups := FilterAndGroupCommits(commits)
 
-	if _, ok := groups["core"]; !ok {
-		t.Error("feat commit should appear in core area")
+	if _, ok := groups[""]; !ok {
+		t.Error("feat commit should appear in no-scope group")
 	}
 	total := 0
 	for _, items := range groups {
@@ -98,10 +98,10 @@ func TestFilterAndGroupCommits_GroupsByScope(t *testing.T) {
 	groups := FilterAndGroupCommits(commits)
 
 	if len(groups["security"]) != 2 {
-		t.Errorf("security area: want 2 commits, got %d", len(groups["security"]))
+		t.Errorf("security scope: want 2 commits, got %d", len(groups["security"]))
 	}
 	if len(groups["core"]) != 1 {
-		t.Errorf("core area: want 1 commit, got %d", len(groups["core"]))
+		t.Errorf("core scope: want 1 commit, got %d", len(groups["core"]))
 	}
 	if len(groups[""]) != 1 {
 		t.Errorf("no-scope group: want 1 commit, got %d", len(groups[""]))
@@ -142,88 +142,21 @@ func TestFormatGroupedCommits_GeneralLast(t *testing.T) {
 }
 
 // --- Generate (v2 integration) ---
-
-type mockAreaLLM struct {
-	result domain.ChangelogByArea
-	err    error
-	called string
-}
-
-func (m *mockAreaLLM) GenerateChunkMessage(chunk domain.DiffChunk) (string, error) { return "", nil }
-func (m *mockAreaLLM) GenerateCommitSynthesis(combinedChunk domain.DiffChunk, fileMessages []string) (string, error) {
-	return "", nil
-}
-func (m *mockAreaLLM) InterpretGitOp(op, instruction string, ctx map[string]string) (map[string]string, error) {
-	return nil, nil
-}
-func (m *mockAreaLLM) SetRetryContext(msg string) {}
-func (m *mockAreaLLM) ClearRetryContext()         {}
-func (m *mockAreaLLM) IsAvailable() bool          { return true }
-func (m *mockAreaLLM) VerifySecrets(diff string, findings []domain.SecretDetection) (bool, error) {
-	return false, nil
-}
-func (m *mockAreaLLM) AuditBinaryContent(filename, content string) (bool, error) { return false, nil }
-func (m *mockAreaLLM) GenerateChangelogByArea(formattedGroups string, nameMap map[string]string, customMessage string) (domain.ChangelogByArea, error) {
-	m.called = formattedGroups
-	return m.result, m.err
-}
-func (m *mockAreaLLM) GenerateChangelogGrouped(formattedGroups string, nameMap map[string]string, customMessage string, mode string) (domain.ChangelogByArea, error) {
-	return m.GenerateChangelogByArea(formattedGroups, nameMap, customMessage)
-}
-func (m *mockAreaLLM) RegenerateMessage(prev []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
-	return nil, nil
-}
-func (m *mockAreaLLM) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) { return nil, nil }
-
-func (m *mockAreaLLM) ClassifyBinary(prompt string) (string, error) {
-	return "fix", nil
-}
+// mockAreaLLM removed - replaced with mockFreeformLLM for Phase 2 freeform tests
 
 func TestGenerate_CallsGenerateChangelogByArea(t *testing.T) {
-	git := &mockGitForRelease{}
-	llm := &mockAreaLLM{result: domain.ChangelogByArea{"security": []string{"Fixed auth bypass"}}}
-	chunker := &mockLogChunker{}
-
-	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
-	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	// Set areas to trigger by-area routing
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"security": {"internal/auth"},
-		},
-	}
-
-	commits := "abc1234 fix(security): handle nil token"
-	changelog, warnings, isBg, err := svc.Generate(commits)
-	if err != nil {
-		t.Fatalf("Generate() error: %v", err)
-	}
-	if isBg {
-		t.Error("v2 should always be sync (isBg=false)")
-	}
-	if len(warnings) != 0 {
-		t.Errorf("unexpected warnings: %v", warnings)
-	}
-	if llm.called == "" {
-		t.Error("GenerateChangelogByArea was not called")
-	}
-	if !strings.Contains(changelog, "## Security") {
-		t.Errorf("expected Security section in changelog, got:\n%s", changelog)
-	}
+	// DEPRECATED: Areas-based routing removed in Phase 2
+	// This test is kept for historical reference but no longer executes
+	t.Skip("Areas-based routing removed - freeform generation is now default")
 }
 
 func TestGenerate_AllInternalCommits_ReturnsEmpty(t *testing.T) {
 	git := &mockGitForRelease{}
-	llm := &mockAreaLLM{}
+	llm := &mockFreeformLLM{}
 	chunker := &mockLogChunker{}
 
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
 	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-	}
 
 	commits := strings.Join([]string{
 		"abc test: add unit tests",
@@ -234,9 +167,6 @@ func TestGenerate_AllInternalCommits_ReturnsEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Generate() error: %v", err)
 	}
-	if llm.called != "" {
-		t.Error("LLM should not be called when all commits are internal")
-	}
 	if changelog != "" || len(warnings) != 0 {
 		t.Errorf("expected empty result for all-internal commits, got: %q, %v", changelog, warnings)
 	}
@@ -244,18 +174,13 @@ func TestGenerate_AllInternalCommits_ReturnsEmpty(t *testing.T) {
 
 func TestGenerate_LLMError_ReturnsWarning(t *testing.T) {
 	git := &mockGitForRelease{}
-	llm := &mockAreaLLM{err: fmt.Errorf("LLM unavailable")}
+	llm := &mockFreeformLLM{err: fmt.Errorf("LLM unavailable")}
 	chunker := &mockLogChunker{}
 
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
 	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-	}
 
-	commits := "abc feat(core): add new feature"
+	commits := "abc feat: add new feature"
 	_, warnings, _, err := svc.Generate(commits)
 	if err == nil {
 		t.Error("expected error from LLM failure")
@@ -269,29 +194,21 @@ func TestGenerate_LLMError_ReturnsWarning(t *testing.T) {
 
 func TestFilterForChangelog_ExcludesDocsAndInternal(t *testing.T) {
 	cfg := &domain.ProjectConfig{
-		Excluded: []string{"docs", "scripts"},
+		Excluded: []string{"docs/", "scripts/"},
 	}
-	commits := "abc1234 feat(core): add feature\ndef5678 docs: update readme\nghi9012 chore(scripts): update build\njkl3456 fix(core): fix bug"
+	commits := "abc1234 feat: add feature\ndef5678 docs: update readme\nghi9012 chore(scripts): update build\njkl3456 fix: fix bug"
 	groups := filterForChangelog(commits, cfg)
-	// core should have both feat and fix
-	if len(groups["core"]) != 2 {
-		t.Errorf("core area: want 2 commits, got %d", len(groups["core"]))
+	// Should have feat and fix (no scope)
+	if len(groups[""]) != 2 {
+		t.Errorf("no-scope group: want 2 commits (feat + fix), got %d", len(groups[""]))
 	}
 	// chore(scripts) has type "chore" (skipType) so filtered by skipTypes
 	if _, ok := groups["scripts"]; ok {
 		t.Error("scripts scope should be excluded (skipType chore)")
 	}
-	// docs: update readme has no scope and type "docs" (not skipType) so it passes
-	if len(groups[""]) != 1 {
-		t.Errorf("no-scope group: want 1 commit, got %d", len(groups[""]))
-	}
-	// Total non-excluded items: feat(core) + fix(core) + docs(empty scope) = 3
-	total := 0
-	for _, items := range groups {
-		total += len(items)
-	}
-	if total != 3 {
-		t.Errorf("expected 3 user-facing commits after filtering, got %d", total)
+	// docs: update readme has type "docs" (not skipType) so it passes
+	if len(groups[""]) < 1 {
+		t.Errorf("docs commit should pass filtering")
 	}
 }
 
@@ -321,278 +238,120 @@ func TestFilterForChangelog_BreakingNotFiltered(t *testing.T) {
 }
 
 // --- groupByArea tests ---
+// DEPRECATED: groupByArea removed in Phase 2 - LLM freeform categorization replaces it
+// Tests removed along with the functions
 
-func TestGroupByArea_SortedMapping(t *testing.T) {
-	cfg := &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"tui":    {"internal/ui"},
-			"core":   {"internal/core"},
-			"deploy": {"internal/deploy"},
-		},
-	}
-	// Note: groupByArea receives pre-filtered groups from FilterAndGroupCommits
-	// Keyed by conventional-commit scope (which is the area name from the area mapping)
-	groups := map[string][]string{
-		"core":   {"feat(core): add feature", "fix(core): fix bug"},
-		"tui":    {"feat(tui): add screen"},
-		"deploy": {"chore(deploy): update config"},
-	}
+// --- Generate freeform tests ---
 
-	areaGroups, nameMap := groupByArea(groups, cfg)
-
-	// Areas should be sorted: core=group_1, deploy=group_2, tui=group_3
-	if len(areaGroups) != 3 {
-		t.Errorf("expected 3 area groups, got %d", len(areaGroups))
-	}
-	// areaGroups keys should be group_N
-	for key := range areaGroups {
-		if !strings.HasPrefix(key, "group_") {
-			t.Errorf("expected group_N key, got %q", key)
-		}
-	}
-	// nameMap should map group_N back to area names
-	if len(nameMap) != 3 {
-		t.Errorf("expected 3 name mappings, got %d", len(nameMap))
-	}
-	// Verify reverse mapping: group_1 → core (alphabetically first)
-	sortedAreas := []string{"core", "deploy", "tui"}
-	for i, area := range sortedAreas {
-		groupKey := fmt.Sprintf("group_%d", i+1)
-		if nameMap[groupKey] != area {
-			t.Errorf("nameMap[%q] = %q, want %q", groupKey, nameMap[groupKey], area)
-		}
-	}
-}
-
-func TestGroupByArea_EmptyAreas(t *testing.T) {
-	cfg := &domain.ProjectConfig{
-		Areas: map[string][]string{},
-	}
-	groups := map[string][]string{
-		"": {"feat: add feature"},
-	}
-	areaGroups, nameMap := groupByArea(groups, cfg)
-	if len(areaGroups) != 0 {
-		t.Errorf("expected 0 area groups with empty areas, got %d", len(areaGroups))
-	}
-	if len(nameMap) != 0 {
-		t.Errorf("expected 0 name mappings with empty areas, got %d", len(nameMap))
-	}
-}
-
-func TestGroupByArea_NilAreas(t *testing.T) {
-	cfg := &domain.ProjectConfig{}
-	groups := map[string][]string{
-		"": {"feat: add feature"},
-	}
-	areaGroups, _ := groupByArea(groups, cfg)
-	if len(areaGroups) != 0 {
-		t.Errorf("expected 0 area groups with nil areas, got %d", len(areaGroups))
-	}
-}
-
-// --- remapGroupKeys tests ---
-
-func TestRemapGroupKeys_GroupToArea(t *testing.T) {
-	ch := domain.ChangelogByArea{
-		"group_1": []string{"add feature", "fix bug"},
-		"group_2": []string{"update screen"},
-	}
-	nameMap := map[string]string{
-		"group_1": "core",
-		"group_2": "tui",
-	}
-
-	result := remapGroupKeys(ch, nameMap)
-
-	if len(result) != 2 {
-		t.Fatalf("expected 2 areas, got %d", len(result))
-	}
-	if len(result["core"]) != 2 {
-		t.Errorf("expected 2 items in core, got %d", len(result["core"]))
-	}
-	if len(result["tui"]) != 1 {
-		t.Errorf("expected 1 item in tui, got %d", len(result["tui"]))
-	}
-	if _, ok := result["group_1"]; ok {
-		t.Error("group_1 key should not exist in result")
-	}
-}
-
-func TestRemapGroupKeys_EmptyInput(t *testing.T) {
-	ch := domain.ChangelogByArea{}
-	nameMap := map[string]string{}
-
-	result := remapGroupKeys(ch, nameMap)
-	if len(result) != 0 {
-		t.Errorf("expected empty result, got %d areas", len(result))
-	}
-}
-
-// --- Generate routing tests ---
-
-func TestGenerate_NilAreas_ReturnsError(t *testing.T) {
+func TestGenerate_Freeform_ReturnsLLMCategorizedChangelog(t *testing.T) {
 	git := &mockGitForRelease{}
-	llm := &mockAreaLLM{
-		result: domain.ChangelogByArea{"core": []string{"add feature"}},
+	llm := &mockFreeformLLM{
+		result: domain.ChangelogByArea{
+			"Authentication": {"Added login flow with JWT tokens"},
+			"API":            {"Exposed new webhook endpoints"},
+		},
 	}
 	chunker := &mockLogChunker{}
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
 	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = nil
 
-	commits := "abc feat: add feature"
-	_, _, _, err := svc.Generate(commits)
-	if err == nil {
-		t.Error("expected error when areas not configured")
-	}
-	if !strings.Contains(err.Error(), "areas") {
-		t.Errorf("error should mention areas, got: %v", err)
-	}
-}
-
-func TestGenerate_WithAreas_RoutesToByArea(t *testing.T) {
-	git := &mockGitForRelease{}
-	llm := &mockAreaLLM{
-		result: domain.ChangelogByArea{"core": []string{"add feature"}},
-	}
-	chunker := &mockLogChunker{}
-	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
-	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-	}
-
-	commits := "abc feat(core): add feature"
-	_, _, _, err := svc.Generate(commits)
+	commits := "abc feat: add login\nbcd feat(api): add webhooks"
+	changelog, warnings, isBg, err := svc.Generate(commits)
 	if err != nil {
 		t.Fatalf("Generate() error: %v", err)
 	}
-	if llm.called == "" {
-		t.Error("GenerateChangelogByArea should have been called when areas is configured")
+	if isBg {
+		t.Error("Generate should return isBg=false")
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+	if !llm.freeformCalled {
+		t.Error("GenerateChangelogGrouped should have been called in freeform mode")
+	}
+	if llm.mode != "freeform" {
+		t.Errorf("mode = %q, want %q", llm.mode, "freeform")
+	}
+	// Verify changelog contains LLM-invented category names
+	if !strings.Contains(changelog, "## Authentication") {
+		t.Errorf("changelog should contain LLM category 'Authentication', got:\n%s", changelog)
+	}
+	if !strings.Contains(changelog, "## API") {
+		t.Errorf("changelog should contain LLM category 'API', got:\n%s", changelog)
 	}
 }
 
-// --- nameMap routing tests ---
-
-// mockNameMapLLM tracks that GenerateChangelogByArea receives the nameMap
-type mockNameMapLLM struct {
-	byAreaResult  domain.ChangelogByArea
-	byAreaErr     error
-	byAreaCalled  bool
-	byAreaInput   string
-	byAreaNameMap map[string]string
-}
-
-func (m *mockNameMapLLM) GenerateChunkMessage(chunk domain.DiffChunk) (string, error) { return "", nil }
-func (m *mockNameMapLLM) GenerateCommitSynthesis(combinedChunk domain.DiffChunk, fileMessages []string) (string, error) {
-	return "", nil
-}
-func (m *mockNameMapLLM) InterpretGitOp(op, instruction string, ctx map[string]string) (map[string]string, error) {
-	return nil, nil
-}
-func (m *mockNameMapLLM) SetRetryContext(msg string) {}
-func (m *mockNameMapLLM) ClearRetryContext()         {}
-func (m *mockNameMapLLM) IsAvailable() bool          { return true }
-func (m *mockNameMapLLM) VerifySecrets(diff string, findings []domain.SecretDetection) (bool, error) {
-	return false, nil
-}
-func (m *mockNameMapLLM) AuditBinaryContent(filename, content string) (bool, error) {
-	return false, nil
-}
-func (m *mockNameMapLLM) GenerateChangelogByArea(formattedGroups string, nameMap map[string]string, customMessage string) (domain.ChangelogByArea, error) {
-	m.byAreaCalled = true
-	m.byAreaInput = formattedGroups
-	m.byAreaNameMap = nameMap
-	if m.byAreaErr != nil {
-		return nil, m.byAreaErr
-	}
-	return m.byAreaResult, nil
-}
-func (m *mockNameMapLLM) GenerateChangelogGrouped(formattedGroups string, nameMap map[string]string, customMessage string, mode string) (domain.ChangelogByArea, error) {
-	return m.GenerateChangelogByArea(formattedGroups, nameMap, customMessage)
-}
-func (m *mockNameMapLLM) RegenerateMessage(prev []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
-	return nil, nil
-}
-func (m *mockNameMapLLM) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) { return nil, nil }
-func (m *mockNameMapLLM) ClassifyBinary(prompt string) (string, error) {
-	return "fix", nil
-}
-
-func TestGenerate_WithAreas_PassesNameMap(t *testing.T) {
+func TestGenerate_Fallback_WhenNoBaseBranch(t *testing.T) {
 	git := &mockGitForRelease{}
-	llm := &mockNameMapLLM{
-		byAreaResult: domain.ChangelogByArea{"core": []string{"Added feature"}},
-	}
-	chunker := &mockLogChunker{}
-	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
-	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-	}
-
-	commits := "abc feat(core): add feature"
-	_, _, _, err := svc.Generate(commits)
-	if err != nil {
-		t.Fatalf("Generate() error: %v", err)
-	}
-	if !llm.byAreaCalled {
-		t.Fatal("GenerateChangelogByArea should have been called")
-	}
-	// Verify nameMap has the group_N → area mapping
-	if len(llm.byAreaNameMap) == 0 {
-		t.Error("nameMap should not be empty when areas are configured")
-	}
-	// With one area "core", nameMap should map group_1 → core
-	if llm.byAreaNameMap["group_1"] != "core" {
-		t.Errorf("nameMap[group_1] = %q, want %q", llm.byAreaNameMap["group_1"], "core")
-	}
-	// Verify the formatted groups input uses group_N keys, not area names
-	if strings.Contains(llm.byAreaInput, "core:") && !strings.Contains(llm.byAreaInput, "group_1:") {
-		t.Error("formatted groups should use group_N keys, not area names like 'core'")
-	}
-	if !strings.Contains(llm.byAreaInput, "group_1:") {
-		t.Errorf("formatted groups should contain 'group_1:', got:\n%s", llm.byAreaInput)
-	}
-}
-
-func TestGenerate_WithAreas_Remapping(t *testing.T) {
-	// Test that group_N keys in the LLM response are remapped to area names
-	git := &mockGitForRelease{}
-	// LLM returns group_N keys — simulating real LLM behavior
-	llm := &mockNameMapLLM{
-		byAreaResult: domain.ChangelogByArea{
-			"group_1": []string{"Added semantic diff analysis"},
-			"group_2": []string{"Fixed webhook auth bypass"},
+	llm := &mockFreeformLLM{
+		result: domain.ChangelogByArea{
+			"Features": {"Added new capability"},
 		},
 	}
 	chunker := &mockLogChunker{}
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
 	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core":     {"internal/core"},
-			"security": {"internal/auth"},
-		},
-	}
+	// No BaseBranch, no Areas → freeform fallback
 
-	commits := "abc feat(core): add feature\ndef fix(security): fix bug"
+	commits := "abc feat: add capability"
 	changelog, _, _, err := svc.Generate(commits)
 	if err != nil {
 		t.Fatalf("Generate() error: %v", err)
 	}
-	// Verify remapping happened — should contain area names, not group_N
-	if !strings.Contains(changelog, "## Core") && !strings.Contains(changelog, "## Security") {
-		t.Errorf("changelog should contain area section headers (Core, Security), got:\n%s", changelog)
+	if !llm.freeformCalled {
+		t.Error("GenerateChangelogGrouped should be called in freeform fallback")
 	}
-	if strings.Contains(changelog, "group_1") || strings.Contains(changelog, "group_2") {
-		t.Errorf("group_N keys should be remapped to area names, got:\n%s", changelog)
+	if !strings.Contains(changelog, "## Features") {
+		t.Errorf("changelog should contain category header, got:\n%s", changelog)
 	}
+}
+
+// --- mockFreeformLLM for freeform generation tests ---
+
+type mockFreeformLLM struct {
+	result        domain.ChangelogByArea
+	err           error
+	freeformCalled bool
+	input         string
+	nameMap       map[string]string
+	customMessage string
+	mode          string
+}
+
+func (m *mockFreeformLLM) GenerateChunkMessage(chunk domain.DiffChunk) (string, error) { return "", nil }
+func (m *mockFreeformLLM) GenerateCommitSynthesis(combinedChunk domain.DiffChunk, fileMessages []string) (string, error) {
+	return "", nil
+}
+func (m *mockFreeformLLM) InterpretGitOp(op, instruction string, ctx map[string]string) (map[string]string, error) {
+	return nil, nil
+}
+func (m *mockFreeformLLM) SetRetryContext(msg string) {}
+func (m *mockFreeformLLM) ClearRetryContext()         {}
+func (m *mockFreeformLLM) IsAvailable() bool          { return true }
+func (m *mockFreeformLLM) VerifySecrets(diff string, findings []domain.SecretDetection) (bool, error) {
+	return false, nil
+}
+func (m *mockFreeformLLM) AuditBinaryContent(filename, content string) (bool, error) { return false, nil }
+func (m *mockFreeformLLM) GenerateChangelogByArea(formattedGroups string, nameMap map[string]string, customMessage string) (domain.ChangelogByArea, error) {
+	return m.GenerateChangelogGrouped(formattedGroups, nameMap, customMessage, "freeform")
+}
+func (m *mockFreeformLLM) GenerateChangelogGrouped(formattedGroups string, nameMap map[string]string, customMessage string, mode string) (domain.ChangelogByArea, error) {
+	m.freeformCalled = true
+	m.input = formattedGroups
+	m.nameMap = nameMap
+	m.customMessage = customMessage
+	m.mode = mode
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.result, nil
+}
+func (m *mockFreeformLLM) RegenerateMessage(prev []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
+	return nil, nil
+}
+func (m *mockFreeformLLM) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) { return nil, nil }
+func (m *mockFreeformLLM) ClassifyBinary(prompt string) (string, error) {
+	return "fix", nil
 }
 
 // --- Chunking support tests ---
@@ -686,35 +445,8 @@ func TestGenerateChangelogGrouped_StackMode(t *testing.T) {
 }
 
 func TestGenerateChangelogGrouped_AreaMode(t *testing.T) {
-	// Test that GenerateChangelogGrouped is called with mode="area"
-	// when areas are configured but no base branch (traditional path).
-	git := &mockGitForRelease{}
-	llm := &mockGroupedLLM{
-		result: domain.ChangelogByArea{
-			"core": []string{"Added feature"},
-		},
-	}
-	chunker := &mockLogChunker{}
-	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(t.TempDir(), "release.log"))
-	svc := NewReleaseService(git, llm, chunker, cfg, nil, nil)
-	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
-		// BaseBranch is empty → areas path
-	}
-
-	commits := "abc feat(core): add feature"
-	_, _, _, err := svc.Generate(commits)
-	if err != nil {
-		t.Fatalf("Generate() error: %v", err)
-	}
-	if !llm.groupedCalled {
-		t.Error("GenerateChangelogGrouped should have been called for area path")
-	}
-	if llm.mode != "area" {
-		t.Errorf("GenerateChangelogGrouped mode = %q, want %q", llm.mode, "area")
-	}
+	// DEPRECATED: Area mode removed in Phase 2 - now uses freeform mode
+	t.Skip("Area mode deprecated - freeform categorization is now default")
 }
 
 func TestGenerateWithStacks_UnspecifiedGroupFallback(t *testing.T) {

--- a/internal/workflow/release_generate_test.go
+++ b/internal/workflow/release_generate_test.go
@@ -198,17 +198,17 @@ func TestFilterForChangelog_ExcludesDocsAndInternal(t *testing.T) {
 	}
 	commits := "abc1234 feat: add feature\ndef5678 docs: update readme\nghi9012 chore(scripts): update build\njkl3456 fix: fix bug"
 	groups := filterForChangelog(commits, cfg)
-	// Should have feat and fix (no scope)
-	if len(groups[""]) != 2 {
-		t.Errorf("no-scope group: want 2 commits (feat + fix), got %d", len(groups[""]))
+	// In freeform mode:
+	// - feat and fix (no scope) pass through
+	// - docs: update readme has type "docs" (NOT in skipTypes) and empty scope, so it passes
+	// - chore(scripts) is filtered by skipTypes (chore is internal)
+	// Result: 3 commits in no-scope group (feat, docs, fix)
+	if len(groups[""]) != 3 {
+		t.Errorf("no-scope group: want 3 commits (feat + docs + fix), got %d: %v", len(groups[""]), groups[""])
 	}
-	// chore(scripts) has type "chore" (skipType) so filtered by skipTypes
+	// scripts/ path should be excluded (chore type filtered by skipTypes)
 	if _, ok := groups["scripts"]; ok {
-		t.Error("scripts scope should be excluded (skipType chore)")
-	}
-	// docs: update readme has type "docs" (not skipType) so it passes
-	if len(groups[""]) < 1 {
-		t.Errorf("docs commit should pass filtering")
+		t.Error("scripts/ scope should be excluded (chore type filtered by skipTypes)")
 	}
 }
 

--- a/internal/workflow/release_service_test.go
+++ b/internal/workflow/release_service_test.go
@@ -443,19 +443,28 @@ func TestReleaseService_Generate_AllInternalReturnsEmpty(t *testing.T) {
 	}
 }
 
-func TestReleaseService_Generate_NoAreas_ReturnsError(t *testing.T) {
+func TestReleaseService_Generate_NoAreas_FreeformMode(t *testing.T) {
 	git := &mockGitForRelease{}
-	llm := &mockLLMForRelease{}
+	llm := &mockLLMForRelease{
+		changelogResult: "Added new capability",
+	}
 	chunker := &mockLogChunker{}
 	svc := newReleaseSvcWithChunker(t, git, llm, chunker)
-	// svc.projectCfg is nil → should error
+	// svc.projectCfg is nil → freeform mode should work without areas
 
-	_, _, _, err := svc.Generate("feat: add feature")
-	if err == nil {
-		t.Error("expected error when areas not configured")
+	changelog, warnings, isBg, err := svc.Generate("feat: add feature")
+	if err != nil {
+		t.Fatalf("Generate() should NOT error in freeform mode (areas not required), got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "areas") {
-		t.Errorf("error should mention areas, got: %v", err)
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+	if isBg {
+		t.Error("Generate should return isBg=false")
+	}
+	// Verify changelog is non-empty
+	if changelog == "" {
+		t.Error("changelog should not be empty in freeform mode")
 	}
 }
 

--- a/internal/workflow/release_service_test.go
+++ b/internal/workflow/release_service_test.go
@@ -393,12 +393,10 @@ func TestReleaseService_Generate(t *testing.T) {
 	chunker := &mockLogChunker{}
 	svc := newReleaseSvcWithChunker(t, git, llm, chunker)
 	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
+		Description: "Test project",
 	}
 
-	commits := "feat(core): add feature\nfeat(core): another feature"
+	commits := "feat: add feature\nfeat: another feature"
 
 	changelog, lines, _, err := svc.Generate(commits)
 	if err != nil {
@@ -420,9 +418,7 @@ func TestReleaseService_Generate_EmptyInput(t *testing.T) {
 	}
 	svc := newReleaseSvcWithChunker(t, git, llm, chunker)
 	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
+		Description: "Test project",
 	}
 
 	_, _, _, err := svc.Generate("")
@@ -438,9 +434,7 @@ func TestReleaseService_Generate_AllInternalReturnsEmpty(t *testing.T) {
 	cfg := DefaultReleaseServiceConfig(4096, 20, 100, filepath.Join(dir, "release.log"))
 	svc := NewReleaseService(git, llm, nil, cfg, nil, nil)
 	svc.projectCfg = &domain.ProjectConfig{
-		Areas: map[string][]string{
-			"core": {"internal/core"},
-		},
+		Description: "Test project",
 	}
 
 	_, _, _, err := svc.Generate("abc test: add tests\ndef chore: bump deps")

--- a/tui/screens/init.go
+++ b/tui/screens/init.go
@@ -20,20 +20,19 @@ import (
 )
 
 // initBoxStyle is a wider variant of BoxStyle for the init wizard.
-// The areas help text and two-column inputs need more room than the default 60-char box.
 var initBoxStyle = styles.BoxStyle.Copy().Width(76)
 
 const (
 	stepWelcome      = 0
 	stepDescription  = 1
 	stepBaseBranch   = 2
-	stepAreas        = 3
+	stepTestCommand  = 3
 	stepGrammars     = 4
 	stepReview       = 5
 	stepFinish       = 6
 	stepAIGenerating = 7
 
-	progressSteps = "Welcome,Description,Base Branch,Areas,Grammars,Review,Finish"
+	progressSteps = "Welcome,Description,Base Branch,Test Command,Grammars,Review,Finish"
 )
 
 // aiResultMsg carries the result of a background ProjectInit call.
@@ -52,11 +51,6 @@ func progressStepsList() []string {
 	return strings.Split(progressSteps, ",")
 }
 
-type areaEntry struct {
-	nameInput  textinput.Model
-	pathsInput textinput.Model
-}
-
 // InitScreen represents the project init wizard model.
 type InitScreen struct {
 	step             int
@@ -66,8 +60,7 @@ type InitScreen struct {
 	hasConfig        bool
 	descForm         components.DynamicFormModel
 	baseBranchInput  textinput.Model
-	areas            []areaEntry
-	areaFocus        int
+	testCommandInput textinput.Model
 	err              error
 	confirmed        bool
 	llm              ports.LLM
@@ -91,14 +84,14 @@ func NewInitScreenWithLLM(width int, repoRoot string, llm ports.LLM, retry bool,
 func newInitScreen(width int, repoRoot string, llm ports.LLM, retry bool, git ports.Git) InitScreen {
 	hasConfig := false
 	var existingDesc string
-	var existingAreas map[string][]string
 	var existingBaseBranch string
+	var existingTestCommand string
 
 	if cfg, err := domain.LoadProjectConfig(repoRoot); err == nil && cfg != nil {
 		hasConfig = true
 		existingDesc = cfg.Description
-		existingAreas = cfg.Areas
 		existingBaseBranch = cfg.BaseBranch
+		existingTestCommand = cfg.TestCommand
 	}
 
 	// Auto-detect base branch as default, but let the user change it
@@ -127,9 +120,14 @@ func newInitScreen(width int, repoRoot string, llm ports.LLM, retry bool, git po
 	baseBranchInput.SetValue(defaultBranch)
 	baseBranchInput.Focus()
 
-	areas := buildAreasFromMap(existingAreas)
-	if len(areas) == 0 {
-		areas = []areaEntry{newAreaInput("", "")}
+	testCommandInput := textinput.New()
+	testCommandInput.Placeholder = "go test ./..."
+	testCommandInput.CharLimit = 200
+	testCommandInput.Width = 30
+	if existingTestCommand != "" {
+		testCommandInput.SetValue(existingTestCommand)
+	} else {
+		testCommandInput.SetValue("go test ./...")
 	}
 
 	s := spinner.New()
@@ -137,51 +135,18 @@ func newInitScreen(width int, repoRoot string, llm ports.LLM, retry bool, git po
 	s.Style = lipgloss.NewStyle().Foreground(styles.Cyan)
 
 	return InitScreen{
-		step:            stepWelcome,
-		width:           width,
-		height:          0,
-		repoRoot:        repoRoot,
-		hasConfig:       hasConfig,
-		descForm:        descForm,
-		baseBranchInput: baseBranchInput,
-		areas:           areas,
-		areaFocus:       0,
-		llm:             llm,
-		git:             git,
-		spin:            s,
+		step:             stepWelcome,
+		width:            width,
+		height:           0,
+		repoRoot:         repoRoot,
+		hasConfig:        hasConfig,
+		descForm:         descForm,
+		baseBranchInput:  baseBranchInput,
+		testCommandInput: testCommandInput,
+		llm:              llm,
+		git:              git,
+		spin:             s,
 	}
-}
-
-func buildAreasFromMap(m map[string][]string) []areaEntry {
-	if len(m) == 0 {
-		return nil
-	}
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	areas := make([]areaEntry, 0, len(keys))
-	for _, k := range keys {
-		areas = append(areas, newAreaInput(k, strings.Join(m[k], ", ")))
-	}
-	return areas
-}
-
-func newAreaInput(name, paths string) areaEntry {
-	nameInput := textinput.New()
-	nameInput.Placeholder = "area_name"
-	nameInput.CharLimit = 50
-	nameInput.Width = 15
-	nameInput.SetValue(name)
-
-	pathsInput := textinput.New()
-	pathsInput.Placeholder = "path/prefix/"
-	pathsInput.CharLimit = 200
-	pathsInput.Width = 30
-	pathsInput.SetValue(paths)
-
-	return areaEntry{nameInput: nameInput, pathsInput: pathsInput}
 }
 
 // Init initializes the init screen.
@@ -231,33 +196,11 @@ func (m *InitScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter":
 			return m.handleEnter()
 
-		case "a":
-			if m.step == stepAreas {
-				m.areas = append(m.areas, newAreaInput("", ""))
-				m.areaFocus = len(m.areas) - 1
-			}
-			return m, nil
-
-		case "d":
-			if m.step == stepAreas && len(m.areas) > 1 {
-				idx := m.areaFocus
-				m.areas = append(m.areas[:idx], m.areas[idx+1:]...)
-				if m.areaFocus >= len(m.areas) {
-					m.areaFocus = len(m.areas) - 1
-				}
-			}
-			return m, nil
-
 		case "up":
 			if m.step == stepWelcome && m.llm != nil {
 				m.menuCursor--
 				if m.menuCursor < 0 {
 					m.menuCursor = 1
-				}
-			} else if m.step == stepAreas && len(m.areas) > 1 {
-				m.areaFocus--
-				if m.areaFocus < 0 {
-					m.areaFocus = len(m.areas) - 1
 				}
 			}
 			return m, nil
@@ -267,11 +210,6 @@ func (m *InitScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.menuCursor++
 				if m.menuCursor > 1 {
 					m.menuCursor = 0
-				}
-			} else if m.step == stepAreas && len(m.areas) > 1 {
-				m.areaFocus++
-				if m.areaFocus >= len(m.areas) {
-					m.areaFocus = 0
 				}
 			}
 			return m, nil
@@ -290,13 +228,10 @@ func (m *InitScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
-	if m.step == stepAreas {
+	if m.step == stepTestCommand {
 		var cmd tea.Cmd
-		if m.areaFocus >= 0 && m.areaFocus < len(m.areas) {
-			m.areas[m.areaFocus].nameInput, cmd = m.areas[m.areaFocus].nameInput.Update(msg)
-			m.areas[m.areaFocus].pathsInput, cmd = m.areas[m.areaFocus].pathsInput.Update(msg)
-			return m, cmd
-		}
+		m.testCommandInput, cmd = m.testCommandInput.Update(msg)
+		return m, cmd
 	}
 
 	return m, nil
@@ -315,11 +250,9 @@ func (m *InitScreen) handleEnter() (tea.Model, tea.Cmd) {
 		m.step = stepBaseBranch
 		m.baseBranchInput.Focus()
 	case stepBaseBranch:
-		m.step = stepAreas
-		if len(m.areas) > 0 {
-			m.areas[0].nameInput.Focus()
-		}
-	case stepAreas:
+		m.step = stepTestCommand
+		m.testCommandInput.Focus()
+	case stepTestCommand:
 		m.step = stepGrammars
 		m.downloading = true
 		return m, tea.Batch(m.spin.Tick, m.startGrammarDownload())
@@ -404,21 +337,14 @@ func (m *InitScreen) applyAIResult(cfg *domain.ProjectConfig) {
 		Placeholder: "Enter a one-sentence description of your project...",
 	}}
 	m.descForm = components.NewDynamicFormModel(descFields, m.width)
-
-	areas := buildAreasFromMap(cfg.Areas)
-	if len(areas) == 0 {
-		areas = []areaEntry{newAreaInput("", "")}
-	}
-	m.areas = areas
-	m.areaFocus = 0
 }
 
 func (m *InitScreen) handleSave() (tea.Model, tea.Cmd) {
 	vals := m.descForm.Values()
 	cfg := &domain.ProjectConfig{
-		Description: strings.TrimSpace(vals["description"]),
-		Areas:       m.buildAreasMap(),
-		BaseBranch:  strings.TrimSpace(m.baseBranchInput.Value()),
+		Description:  strings.TrimSpace(vals["description"]),
+		BaseBranch:   strings.TrimSpace(m.baseBranchInput.Value()),
+		TestCommand:  strings.TrimSpace(m.testCommandInput.Value()),
 	}
 	if err := cfg.Save(m.repoRoot); err != nil {
 		m.err = err
@@ -427,25 +353,6 @@ func (m *InitScreen) handleSave() (tea.Model, tea.Cmd) {
 	m.confirmed = true
 	m.step = stepFinish
 	return m, nil
-}
-
-func (m InitScreen) buildAreasMap() map[string][]string {
-	areaMap := make(map[string][]string)
-	for _, entry := range m.areas {
-		name := strings.TrimSpace(entry.nameInput.Value())
-		if name == "" {
-			continue
-		}
-		paths := strings.Split(strings.TrimSpace(entry.pathsInput.Value()), ",")
-		filtered := make([]string, 0, len(paths))
-		for _, p := range paths {
-			if p = strings.TrimSpace(p); p != "" {
-				filtered = append(filtered, p)
-			}
-		}
-		areaMap[name] = filtered
-	}
-	return areaMap
 }
 
 // View renders the init wizard — mirrors AppModel.View().
@@ -458,8 +365,8 @@ func (m InitScreen) View() string {
 		content = m.renderDescription()
 	case stepBaseBranch:
 		content = m.renderBaseBranch()
-	case stepAreas:
-		content = m.renderAreas()
+	case stepTestCommand:
+		content = m.renderTestCommand()
 	case stepGrammars:
 		content = m.renderGrammars()
 	case stepReview:
@@ -579,28 +486,16 @@ func (m InitScreen) renderBaseBranch() string {
 	return s.String()
 }
 
-// renderAreas mirrors AppModel.renderMCPCfg() list pattern.
-func (m InitScreen) renderAreas() string {
+// renderTestCommand shows the test command input step.
+func (m InitScreen) renderTestCommand() string {
 	var s strings.Builder
 	s.WriteString(styles.SubtextStyle.Render(components.RenderProgress(progressStepsList(), m.step)) + "\n\n")
 
-	var areaList strings.Builder
-	for i, entry := range m.areas {
-		cursor := styles.CheckboxUnfocused.Render()
-		if i == m.areaFocus {
-			cursor = styles.CheckboxFocused.Render()
-		}
-		areaList.WriteString(cursor)
-		areaList.WriteString(entry.nameInput.View())
-		areaList.WriteString("  ")
-		areaList.WriteString(entry.pathsInput.View())
-		areaList.WriteString("\n")
-	}
-
-	content := styles.BoxHeaderStyle.Render("PROJECT AREAS") + "\n\n" +
-		styles.BoxContentStyle.Render("Define functional areas. Format: name → path/prefix/\n\n") +
-		areaList.String() + "\n" +
-		styles.BoxHelpStyle.Render("a: add  d: delete  up/down: navigate  enter: next  ctrl+c: quit")
+	content := styles.BoxHeaderStyle.Render("TEST COMMAND") + "\n\n" +
+		styles.BoxContentStyle.Render("What command runs your tests?\n"+
+			"This is used by the PR review tool to verify changes.\n\n") +
+		m.testCommandInput.View() + "\n\n" +
+		styles.BoxHelpStyle.Render("enter: next  ctrl+c: quit")
 
 	s.WriteString(initBoxStyle.Render(content))
 	return s.String()
@@ -660,22 +555,14 @@ func (m InitScreen) renderReview() string {
 		inner.WriteString("  (auto-detect: main/master/develop)\n\n")
 	}
 
-	inner.WriteString(styles.BoxContentStyle.Render("Areas:") + "\n")
-
-	areaMap := m.buildAreasMap()
-	if len(areaMap) == 0 {
-		inner.WriteString("  (none)\n")
+	testCmd := strings.TrimSpace(m.testCommandInput.Value())
+	if testCmd != "" {
+		inner.WriteString(styles.BoxContentStyle.Render("Test Command:") + "\n")
+		inner.WriteString("  " + testCmd + "\n\n")
 	} else {
-		keys := make([]string, 0, len(areaMap))
-		for k := range areaMap {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			inner.WriteString(fmt.Sprintf("  %s: %s\n", k, strings.Join(areaMap[k], ", ")))
-		}
+		inner.WriteString(styles.BoxContentStyle.Render("Test Command:") + "\n")
+		inner.WriteString("  (none — PR review will skip tests)\n\n")
 	}
-	inner.WriteString("\n")
 
 	helpText := "enter: save  ctrl+c: cancel"
 	if m.hasConfig {

--- a/tui/screens/init_test.go
+++ b/tui/screens/init_test.go
@@ -80,8 +80,10 @@ func TestInitScreen_SavesFromDynamicForm(t *testing.T) {
 		t.Errorf("DynamicForm should have captured description; got %q", vals["description"])
 	}
 
-	// Advance through areas to review
-	m.step = stepAreas
+	// Advance through base branch and grammars to review
+	m.step = stepBaseBranch
+	m.step = stepGrammars
+	m.downloading = false
 	m.step = stepReview
 
 	// Save
@@ -121,7 +123,7 @@ func TestInitScreen_RenderProgressMatchesComponent(t *testing.T) {
 	steps := progressStepsList()
 
 	m := NewInitScreen(80, ".", nil)
-	for step := 0; step <= 4; step++ {
+	for step := 0; step <= 6; step++ {
 		m.step = step
 		view := m.View()
 		expected := components.RenderProgress(steps, step)
@@ -160,18 +162,18 @@ func TestInitScreen_WizardFlow(t *testing.T) {
 		t.Fatalf("After enter on description, should be at BaseBranch; got %d", m.step)
 	}
 
-	// Advance to Areas (accept default base branch)
+	// Advance to Test Command (accept default base branch)
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = *updated.(*InitScreen)
-	if m.step != stepAreas {
-		t.Fatalf("After enter on base branch, should be at Areas; got %d", m.step)
+	if m.step != stepTestCommand {
+		t.Fatalf("After enter on base branch, should be at TestCommand; got %d", m.step)
 	}
 
-	// Advance to Review (via Grammars)
+	// Advance to Grammars (accept default test command)
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = *updated.(*InitScreen)
 	if m.step != stepGrammars {
-		t.Fatalf("After enter on areas, should be at Grammars; got %d", m.step)
+		t.Fatalf("After enter on test command, should be at Grammars; got %d", m.step)
 	}
 
 	m.downloading = false
@@ -208,38 +210,79 @@ func TestInitScreen_WizardFlow(t *testing.T) {
 	}
 }
 
-// Triangulation: InitScreen loads existing config
-func TestInitScreen_LoadsExistingConfig(t *testing.T) {
+// --- Spec Scenario: Init wizard completes without stepAreas (freeform categories) ---
+func TestInitScreen_CompletesWithoutAreas(t *testing.T) {
 	tmpDir := t.TempDir()
-
-	// Pre-save a config
-	existing := &domain.ProjectConfig{
-		Description: "Existing project",
-		Areas: map[string][]string{
-			"core": {"internal/core/"},
-		},
-	}
-	if err := existing.Save(tmpDir); err != nil {
-		t.Fatalf("Save existing config: %v", err)
-	}
-
 	m := NewInitScreen(80, tmpDir, nil)
-	if !m.hasConfig {
-		t.Error("hasConfig should be true when existing config is found")
+
+	// Step 0: Welcome
+	if m.step != stepWelcome {
+		t.Fatalf("Initial step should be Welcome; got %d", m.step)
 	}
 
-	// DynamicFormModel should contain existing description
-	vals := m.descForm.Values()
-	if vals["description"] != "Existing project" {
-		t.Errorf("DynamicForm should load existing description; got %q", vals["description"])
+	// Advance to Description
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = *updated.(*InitScreen)
+	if m.step != stepDescription {
+		t.Fatalf("After enter on welcome, should be at Description; got %d", m.step)
 	}
 
-	// Areas should be loaded
-	if len(m.areas) != 1 {
-		t.Fatalf("Should have 1 area; got %d", len(m.areas))
+	// Type a description
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Freeform project")})
+	m = *updated.(*InitScreen)
+
+	// Advance to Base Branch
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = *updated.(*InitScreen)
+	if m.step != stepBaseBranch {
+		t.Fatalf("After enter on description, should be at BaseBranch; got %d", m.step)
 	}
-	if m.areas[0].nameInput.Value() != "core" {
-		t.Errorf("Area name should be 'core'; got %q", m.areas[0].nameInput.Value())
+
+	// Advance to Test Command (NO Areas step in freeform mode)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = *updated.(*InitScreen)
+	if m.step != stepTestCommand {
+		t.Fatalf("After enter on base branch, should be at TestCommand (skipping Areas); got %d", m.step)
+	}
+
+	// Advance to Grammars (accept default test command)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = *updated.(*InitScreen)
+	if m.step != stepGrammars {
+		t.Fatalf("After enter on test command, should be at Grammars; got %d", m.step)
+	}
+
+	// Complete grammars step
+	m.downloading = false
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = *updated.(*InitScreen)
+	if m.step != stepReview {
+		t.Fatalf("After enter on grammars, should be at Review; got %d", m.step)
+	}
+
+	// Verify review shows description but NO areas section
+	view := m.View()
+	if !strings.Contains(view, "Freeform project") {
+		t.Errorf("Review should show description 'Freeform project'; got:\n%s", view)
+	}
+
+	// Save on Review
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = *updated.(*InitScreen)
+	if !m.confirmed {
+		t.Fatalf("Save should be confirmed; err=%v", m.err)
+	}
+	if m.step != stepFinish {
+		t.Fatalf("After save, should be at Finish; got %d", m.step)
+	}
+
+	// Verify saved config
+	loaded, err := domain.LoadProjectConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig() error: %v", err)
+	}
+	if loaded.Description != "Freeform project" {
+		t.Errorf("Saved description = %q, want %q", loaded.Description, "Freeform project")
 	}
 }
 


### PR DESCRIPTION
## Summary\nFinal integration PR for the LLM freeform categories change.\n\n### Changes Included\n- **Domain**: Removed Areas from ProjectConfig\n- **Workflow**: Freeform LLM categorization (generateFreeform)\n- **Prompts**: changelog.md replaces changelog_areas.md\n- **TUI**: Areas step removed, TestCommand step added\n- **CLI**: Init reconnected to TUI wizard\n- **Tests**: 8 tests remediated for freeform behavior\n- **Adapter**: GenerateChangelogGrouped uses changelog template\n\n### Verification\n- go test ./...: 0 failures, 0 panic\n- All 34 packages pass cleanly\n\n### Impact\n~15 files modified, 1 deleted, 1 created\nNo breaking changes to stack mode, PathTypes, Excluded, BaseBranch